### PR TITLE
Circuit update

### DIFF
--- a/qctrlopencontrols/qiskit/__init__.py
+++ b/qctrlopencontrols/qiskit/__init__.py
@@ -18,5 +18,6 @@ qiskit module
 =============
 """
 
-from .constants import (FIX_DURATION_UNITARY, INSTANT_UNITARY)
+from .constants import (FIX_DURATION_UNITARY, INSTANT_UNITARY,
+                        DEFAULT_PRE_POST_GATE_PARAMETERS)
 from .quantum_circuit import convert_dds_to_quantum_circuit

--- a/qctrlopencontrols/qiskit/constants.py
+++ b/qctrlopencontrols/qiskit/constants.py
@@ -18,6 +18,8 @@ qiskit.constants
 ================
 """
 
+import numpy as np
+
 FIX_DURATION_UNITARY = 'fixed duration unitary'
 """Algorithm to convert a DDS to Quantum circuit
 where the unitaries are considered as gates with finite duration
@@ -26,4 +28,8 @@ where the unitaries are considered as gates with finite duration
 INSTANT_UNITARY = 'instant unitary'
 """Algorithm to convert a DDS to Quantum circuit where the
 unitaties are considered as instantaneous operation.
+"""
+
+DEFAULT_PRE_POST_GATE_PARAMETERS = (np.pi / 2, -np.pi / 2, np.pi / 2)
+"""Parameters of a default U3 gate for pre-post rotation for circuits.
 """

--- a/qctrlopencontrols/qiskit/quantum_circuit.py
+++ b/qctrlopencontrols/qiskit/quantum_circuit.py
@@ -219,9 +219,6 @@ def convert_dds_to_quantum_circuit(
     if target_qubits is None:
         target_qubits = [0]
 
-    #if pre_post_gate_parameters is None:
-    #    pre_post_gate_parameters =
-
     if (pre_post_gate_parameters is not None and
             len(pre_post_gate_parameters) != 3):
         raise ArgumentsValueError('Pre-Post gate parameters must be a list of 3 '

--- a/qctrlopencontrols/qiskit/quantum_circuit.py
+++ b/qctrlopencontrols/qiskit/quantum_circuit.py
@@ -152,11 +152,11 @@ def convert_dds_to_quantum_circuit(
     pre_post_gate_parameters : tuple or None, optional
         Tuple of (length 3) floating point numbers that correspond to :math:`\\theta,
         \\phi, \\lambda` parameters respectively in `U3` gate defined in Qiskit
-        as `U3Gate(theta, phi, lamda)`. Qiskit documentation suggests this to be
+        as `U3Gate(theta, phi, lambda)`. Qiskit documentation suggests this to be
         the most generalized definition of unitary gates. Defaults to
         (pi/2, -pi/2, pi/2) that corresponds to a :math:`pi/2`
         rotation around X-axis; if None, the resulting circuit will have no `pre` or `post`
-        gater. See `IBM-Q Documentation
+        gates. See `IBM-Q Documentation
         <https://quantumexperience.ng.bluemix.net/proxy/tutorial/full-user-guide/
         002-The_Weird_and_Wonderful_World_of_the_Qubit/004-advanced_qubit_gates.html?` _.
     add_measurement : bool, optional

--- a/tests/test_qiskit_sequence.py
+++ b/tests/test_qiskit_sequence.py
@@ -75,18 +75,13 @@ def _create_test_sequence(sequence_scheme):
     return sequence
 
 
-def _check_circuit_unitary(pre_post_gate_parameters):
+def _check_circuit_unitary(pre_post_gate_parameters, multiplier):
     """Check the unitary of a dynamic decoupling operation
     """
 
     backend = 'unitary_simulator'
     number_of_shots = 1
     backend_simulator = BasicAer.get_backend(backend)
-
-    if pre_post_gate_parameters is None:
-        multiplier = (1. / np.power(2, 0.5)) * np.array([[1, -1j], [-1j, 1]], dtype='complex')
-    else:
-        multiplier = np.array([[1, 0], [0, 1]])
 
     for sequence_scheme in ['Carr-Purcell', 'Carr-Purcell-Meiboom-Gill',
                             'Uhrig single-axis', 'periodic single-axis', 'Walsh single-axis',
@@ -115,9 +110,12 @@ def test_identity_operation():
     """Tests if the Dynamic Decoupling Sequence gives rise to Identity
     operation in Qiskit
     """
+    _multiplier = np.array([[1, 0], [0, 1]])
+    _check_circuit_unitary([0., 0., 0.], _multiplier)
+    _check_circuit_unitary(None, _multiplier)
 
-    _check_circuit_unitary([0., 0., 0.])
-    _check_circuit_unitary(None)
+    _multiplier = (1. / np.power(2, 0.5)) * np.array([[1, -1j], [-1j, 1]], dtype='complex')
+    _check_circuit_unitary([np.pi / 2, -np.pi / 2, np.pi / 2], _multiplier)
 
 if __name__ == '__main__':
     pass


### PR DESCRIPTION
Behaviour of `pre_post_gate_parameters` updated.

Accepts a tuple of 3 numbers.
1. Default is a tuple corresponding to a X-pi/2 rotation
2. If None, it omits any pre-post gates from the circuit
3. Otherwise it creates a `U3(...)` op as pre-post gate in the circuit 