### PR TITLE
Added figure compatibility with qctrl-visualizer

### DIFF
--- a/qctrlopencontrols/driven_controls/driven_control.py
+++ b/qctrlopencontrols/driven_controls/driven_control.py
@@ -606,17 +606,9 @@ class DrivenControl(object):   #pylint: disable=too-few-public-methods
                 'times': plot_time}
 
         if coordinates == CYLINDRICAL:
-
-            x_plot = plot_amplitude_x
-            y_plot = plot_amplitude_y
-            x_plot[np.equal(x_plot, -0.0)] = 0.
-            y_plot[np.equal(y_plot, -0.0)] = 0.
-            azimuthal_angles_plot = np.arctan2(y_plot, x_plot)
-            amplitudes_plot = np.sqrt(np.abs(x_plot**2 + y_plot**2))
-
             plot_dictionary = {
-                'rabi_rates': amplitudes_plot,
-                'azimuthal_angles': azimuthal_angles_plot,
+                'rabi_rates': plot_amplitude_x,
+                'azimuthal_angles': plot_amplitude_y,
                 'detunings': plot_amplitude_z,
                 'times': plot_time}
         return plot_dictionary

--- a/qctrlopencontrols/dynamic_decoupling_sequences/dynamic_decoupling_sequence.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/dynamic_decoupling_sequence.py
@@ -150,7 +150,7 @@ class DynamicDecouplingSequence(object):   #pylint: disable=too-few-public-metho
         Returns
         -------
         dict
-            Dictionary with plot data that can be used by the plot_series
+            Dictionary with plot data that can be used by the plot_sequences
             method of the qctrl-visualizer package. It has keywords 'Rabi'
             and 'Detuning'.
         """

--- a/qctrlopencontrols/dynamic_decoupling_sequences/dynamic_decoupling_sequence.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/dynamic_decoupling_sequence.py
@@ -144,6 +144,32 @@ class DynamicDecouplingSequence(object):   #pylint: disable=too-few-public-metho
 
         return len(self.offsets)
 
+    def export(self):
+        """ Returns a dictionary formatted for plotting using the qctrl-visualizer package.
+
+        Returns
+        -------
+        dict
+            Dictionary with plot data that can be used by the plot_series
+            method of the qctrl-visualizer package. It has keywords 'Rabi'
+            and 'Detuning'.
+        """
+
+        plot_dictionary = {}
+
+        plot_r = self.rabi_rotations
+        plot_theta = self.azimuthal_angles
+        plot_offsets = self.offsets
+        plot_detunings = self.detuning_rotations
+
+        plot_dictionary["Rabi"] = [{'rotation': r*np.exp(1.j*theta), 'offset': t}
+            for r, theta, t in zip(plot_r, plot_theta, plot_offsets) ]
+
+        plot_dictionary["Detuning"] = [{'rotation': v, 'offset': t}
+            for v, t in zip(plot_detunings, plot_offsets) ]
+
+        return plot_dictionary
+
     def get_plot_formatted_arrays(self, plot_format=MATPLOTLIB):
         """Gets arrays for plotting a pulse.
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Added an export method to driven control to allow plotting with qctrl-visualizer.
- Added an export method to dynamical decoupling sequences to allow plotting with qctrl-visualizer.
- Fixed an issue with the get_plot_formatted_arrays method in driven_controls that caused the wrong graph to be plotted in cylindrical coordinates.

@qctrl/support
