### PR TITLE
[QENG-716] Fixing DDS that do not produce identities

### DIFF
--- a/qctrlopencontrols/dynamic_decoupling_sequences/driven_controls.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/driven_controls.py
@@ -231,10 +231,10 @@ def convert_dds_to_driven_control(
             pulse_start_ends[op_idx, 1] = pulse_mid_points[op_idx] + half_pulse_duration
         else:
             pulse_start_ends[op_idx, 0] = pulse_mid_points[op_idx] - \
-                                          0.5 * operations[3, op_idx] / maximum_detuning_rate
+                                          0.5 * np.abs(operations[3, op_idx]) / maximum_detuning_rate
 
             pulse_start_ends[op_idx, 1] = pulse_mid_points[op_idx] + \
-                                          0.5 * operations[3, op_idx] / maximum_detuning_rate
+                                          0.5 * np.abs(operations[3, op_idx]) / maximum_detuning_rate
 
     # check if any of the pulses have gone outside the time limit [0, sequence_duration]
     # if yes, adjust the segment timing

--- a/qctrlopencontrols/dynamic_decoupling_sequences/driven_controls.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/driven_controls.py
@@ -231,10 +231,10 @@ def convert_dds_to_driven_control(
             pulse_start_ends[op_idx, 1] = pulse_mid_points[op_idx] + half_pulse_duration
         else:
             pulse_start_ends[op_idx, 0] = pulse_mid_points[op_idx] - \
-                                          0.5 * np.abs(operations[3, op_idx]) / maximum_detuning_rate
+                                          0.5 * operations[3, op_idx] / maximum_detuning_rate
 
             pulse_start_ends[op_idx, 1] = pulse_mid_points[op_idx] + \
-                                          0.5 * np.abs(operations[3, op_idx]) / maximum_detuning_rate
+                                          0.5 * operations[3, op_idx] / maximum_detuning_rate
 
     # check if any of the pulses have gone outside the time limit [0, sequence_duration]
     # if yes, adjust the segment timing

--- a/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
@@ -73,7 +73,7 @@ def _add_pre_post_rotations(
     # which is the same value as the initial pi/2-pulse
     final_azimuthal = 0.
 
-    # These lists have '1' if the pulse is of the specificed type, '0' if it is not
+    # These lists have 1 if the pulse is of the specificed type, 0 if it is not
     is_x_pi_pulse = np.where(np.logical_and(np.isclose(rabi_rotations, np.pi),
                                             np.isclose(azimuthal_angles, 0.)),
                              1,
@@ -83,8 +83,8 @@ def _add_pre_post_rotations(
                              1,
                              0)
 
-    # Setting the azimuthal angle of the pi/2-pulse to pi if the sum of the number
-    # X pi-pulses and Z pi-pulses is an even number
+    # Setting the azimuthal angle of the final pi/2-pulse to pi if the sum of
+    # the number of X pi-pulses and Z pi-pulses is even
     if (sum(is_x_pi_pulse) + sum(is_z_pi_pulse))%2 == 0:
         final_azimuthal = np.pi
 

--- a/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
@@ -41,7 +41,7 @@ def _add_pre_post_rotations(
     The sign of the final pi/2-pulse is inverted if the number of X or Y pi-pulses
     in the original sequence is even (odd), as long as the number of Y or Z pi-pulses
     is also even (odd). This is necessary to make sure that all the contributions of
-    X gates cancel out.
+    the X gates cancel out.
 
     Parameters
     ----------
@@ -63,13 +63,14 @@ def _add_pre_post_rotations(
         resulting after the addition of pi/2 pulses at the start and end of the sequence.
     """
 
-    # The azimuthal angle of the final pulse is 0 if the number of X/Y pi-pulses is odd,
-    # and pi if the number of offsets is even. However, these two values invert again if
-    # there is an odd number of Y/Z pi-pulses in the sequence. These conditions mean that
-    # the sign of the final pi/2-pulse should be inverted is the numbers X/Y pulses and
-    # Y/Z pulses are either both odd or both even.
+    # If there is an even number of Y and Z pi-pulses in the sequence, the azimuthal angle
+    # of the final pulse is 0 if the number of X and Y pi-pulses is odd, and pi if the number
+    # of X/Y pulses is even. These two values are swapped if there is an odd number of Y/Z
+    # pi-pulses in the sequence. Together, these conditions mean that the azimuthal angle of
+    # the final pi/2-pulse is pi if the numbers of X/Y pulses and Y/Z pulses have the same parity.
     final_azimuthal = 0.
 
+    # These lists have True if the pulse is of the specificed type, False if it is not
     is_x_pi_pulse = np.logical_and(np.isclose(rabi_rotations, np.pi),
                                    np.isclose(azimuthal_angles, 0.))
     is_y_pi_pulse = np.logical_and(np.isclose(rabi_rotations, np.pi),
@@ -77,9 +78,11 @@ def _add_pre_post_rotations(
     is_z_pi_pulse = np.logical_and(np.isclose(rabi_rotations, 0.),
                                    np.isclose(detuning_rotations, np.pi))
 
+    # These lists have '1' if the pulse is X/Y (Y/Z), and '0' if it is not
     is_xy_pi_pulse = np.where(np.logical_or(is_x_pi_pulse, is_y_pi_pulse), 1, 0)
     is_yz_pi_pulse = np.where(np.logical_or(is_y_pi_pulse, is_z_pi_pulse), 1, 0)
 
+    # Azimuthal angles is pi if the parity is the same
     if (sum(is_xy_pi_pulse)%2 == sum(is_yz_pi_pulse)%2):
         final_azimuthal = np.pi
 

--- a/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
@@ -78,27 +78,21 @@ def _add_pre_post_rotations(
     final_azimuthal = np.pi
     detuning_value = 0
 
-    # These lists have 1 if the pulse is of the specificed type, 0 if it is not
-    is_x_pi_pulse = np.where(np.logical_and(np.isclose(rabi_rotations, np.pi),
-                                            np.isclose(azimuthal_angles, 0.)),
-                             1,
-                             0)
-    is_y_pi_pulse = np.where(np.logical_and(np.isclose(rabi_rotations, np.pi),
-                                            np.isclose(azimuthal_angles, np.pi/2.)),
-                             1,
-                             0)
-    is_z_pi_pulse = np.where(np.logical_and(np.isclose(rabi_rotations, 0.),
-                                            np.isclose(detuning_rotations, np.pi)),
-                             1,
-                             0)
+    # Count the number of X, Y, and Z pi-pulses
+    x_pi_pulses = np.count_nonzero(np.logical_and(np.isclose(rabi_rotations, np.pi),
+                                                  np.isclose(azimuthal_angles, 0.)))
+    y_pi_pulses = np.count_nonzero(np.logical_and(np.isclose(rabi_rotations, np.pi),
+                                                  np.isclose(azimuthal_angles, np.pi/2.)))
+    z_pi_pulses = np.count_nonzero(np.logical_and(np.isclose(rabi_rotations, 0.),
+                                                  np.isclose(detuning_rotations, np.pi)))
 
     # The sequence results in an X gate, rather than the identity, if the number
     # of X and Y gates is odd
-    remainder_x = ((sum(is_x_pi_pulse) + sum(is_y_pi_pulse))%2 == 1)
+    remainder_x = ((x_pi_pulses + y_pi_pulses)%2 == 1)
 
     # The sequence results in a Z gate, rather than the identity, if the number
     # of Y and Z gates is odd
-    remainder_z = ((sum(is_y_pi_pulse) + sum(is_z_pi_pulse))%2 == 1)
+    remainder_z = ((y_pi_pulses + z_pi_pulses)%2 == 1)
 
     # If there is an X gate left over, but no Z gate, we just invert the direction
     # of the last pi/2-pulse to cancel it out

--- a/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
@@ -35,9 +35,13 @@ def _add_pre_post_rotations(
         rabi_rotations,
         azimuthal_angles,
         detuning_rotations):
-    """Adds a pre-post pi.2 rotation at the
+    """
+    Adds a pre-post pi.2 rotation at the
     start and end of the sequence.
 
+    The sign of the final pi/2-pulse is inverted if the number of pulses (offsets)
+    in the original sequence is even, in order to make sure that the output is an
+    identity gate.
 
     Parameters
     ----------
@@ -59,6 +63,12 @@ def _add_pre_post_rotations(
         resulting after the addition of pi/2 pulses at the start and end of the sequence.
     """
 
+    # The azimuthal angle of the final pulse is 0 if the number of offsets is odd,
+    # and pi if the number of offsets is even.
+    final_azimuthal = 0.
+    if len(offsets)%2 == 0:
+        final_azimuthal = np.pi
+
     offsets = np.insert(offsets,
                         [0, offsets.shape[0]],  # pylint: disable=unsubscriptable-object
                         [0, duration])
@@ -69,7 +79,7 @@ def _add_pre_post_rotations(
     azimuthal_angles = np.insert(
         azimuthal_angles,
         [0, azimuthal_angles.shape[0]],  # pylint: disable=unsubscriptable-object
-        [0, 0])
+        [0, final_azimuthal])
     detuning_rotations = np.insert(
         detuning_rotations,
         [0, detuning_rotations.shape[0]],  # pylint: disable=unsubscriptable-object
@@ -79,7 +89,7 @@ def _add_pre_post_rotations(
 
 
 def new_predefined_dds(scheme=SPIN_ECHO, **kwargs):
-    """Create a new instance of ne of the predefined
+    """Create a new instance of one of the predefined
     dynamic decoupling sequence
 
     Parameters
@@ -209,7 +219,7 @@ def _new_ramsey_sequence(duration=None,
     if pre_post_rotation:
         offsets = duration * np.array([0.0, 1.])
         rabi_rotations = np.array([np.pi/2, np.pi/2])
-        azimuthal_angles = np.zeros(offsets.shape)
+        azimuthal_angles = np.array([0., np.pi])
         detuning_rotations = np.zeros(offsets.shape)
 
     return DynamicDecouplingSequence(

--- a/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
@@ -35,8 +35,7 @@ def _add_pre_post_rotations(
         rabi_rotations,
         azimuthal_angles,
         detuning_rotations):
-    """
-    Adds a pre-post pi.2 rotation at the
+    """Adds a pre-post pi.2 rotation at the
     start and end of the sequence.
 
     The sign of the final pi/2-pulse is inverted if the number of pulses (offsets)
@@ -89,7 +88,7 @@ def _add_pre_post_rotations(
 
 
 def new_predefined_dds(scheme=SPIN_ECHO, **kwargs):
-    """Create a new instance of one of the predefined
+    """Create a new instance of ne of the predefined
     dynamic decoupling sequence
 
     Parameters

--- a/tests/test_predefined_dynamical_decoupling.py
+++ b/tests/test_predefined_dynamical_decoupling.py
@@ -59,7 +59,7 @@ def test_ramsey():
         pre_post_rotation=True)
 
     _rabi_rotations = np.array([np.pi/2, np.pi/2])
-    _azimuthal_angles = np.array([0., 0.])
+    _azimuthal_angles = np.array([0., np.pi])
     _detuning_rotations = np.array([0., 0.])
 
     assert np.allclose(_rabi_rotations, sequence.rabi_rotations)
@@ -140,7 +140,7 @@ def test_curr_purcell():
                          _spacing * 0.5 + 2 * _spacing, _spacing * 0.5 + 3 * _spacing,
                          duration])
     _rabi_rotations = np.array([np.pi/2, np.pi, np.pi, np.pi, np.pi, np.pi/2])
-    _azimuthal_angles = np.array([0, 0, 0, 0, 0, 0])
+    _azimuthal_angles = np.array([0, 0, 0, 0, 0, np.pi])
     _detuning_rotations = np.array([0, 0, 0, 0, 0, 0])
 
     assert np.allclose(_offsets, sequence.offsets)
@@ -183,7 +183,7 @@ def test_curr_purcell_meiboom_sequence():   # pylint: disable=invalid-name
     _offsets = np.array([0, _spacing * 0.5, _spacing * 0.5 + _spacing,
                          _spacing * 0.5 + 2 * _spacing, _spacing * 0.5 + 3 * _spacing, duration])
     _rabi_rotations = np.array([np.pi/2, np.pi, np.pi, np.pi, np.pi, np.pi/2])
-    _azimuthal_angles = np.array([0, np.pi / 2, np.pi / 2, np.pi / 2, np.pi / 2, 0])
+    _azimuthal_angles = np.array([0, np.pi / 2, np.pi / 2, np.pi / 2, np.pi / 2, np.pi])
     _detuning_rotations = np.array([0, 0, 0, 0, 0, 0])
 
     assert np.allclose(_offsets, sequence.offsets)
@@ -231,7 +231,7 @@ def test_uhrig_single_axis_sequence():
                          [0, duration])
 
     _rabi_rotations = np.array([np.pi/2, np.pi, np.pi, np.pi, np.pi, np.pi/2])
-    _azimuthal_angles = np.array([0., np.pi / 2, np.pi / 2, np.pi / 2, np.pi / 2, 0.])
+    _azimuthal_angles = np.array([0., np.pi / 2, np.pi / 2, np.pi / 2, np.pi / 2, np.pi])
     _detuning_rotations = np.array([0., 0, 0, 0, 0, 0.])
 
     assert np.allclose(_offsets, sequence.offsets)
@@ -278,7 +278,7 @@ def test_periodic_single_axis_sequence():      # pylint: disable=invalid-name
                          [0, duration])
 
     _rabi_rotations = np.array([np.pi/2, np.pi, np.pi, np.pi, np.pi, np.pi/2])
-    _azimuthal_angles = np.array([0, 0, 0, 0, 0, 0])
+    _azimuthal_angles = np.array([0, 0, 0, 0, 0, np.pi])
     _detuning_rotations = np.array([0, 0, 0, 0, 0, 0])
 
     assert np.allclose(_offsets, sequence.offsets)
@@ -339,6 +339,7 @@ def test_walsh_single_axis_sequence():
     _rabi_rotations = np.insert(_rabi_rotations, [0, _rabi_rotations.shape[0]],
                                 [np.pi/2, np.pi/2])
     _azimuthal_angles = np.zeros(_offsets.shape)
+    _azimuthal_angles[-1] = np.pi
     _detuning_rotations = np.zeros(_offsets.shape)
 
     assert np.allclose(_offsets, sequence.offsets)
@@ -419,6 +420,7 @@ def test_quadratic_sequence():
                                     [0, 0])
 
     _azimuthal_angles = np.zeros(_offsets.shape)
+    _azimuthal_angles[-1] = np.pi
 
     assert np.allclose(_offsets, sequence.offsets)
     assert np.allclose(_rabi_rotations, sequence.rabi_rotations)
@@ -523,7 +525,7 @@ def test_xyconcatenated_sequence():
     _azimuthal_angles = np.insert(
         _azimuthal_angles,
         [0, _azimuthal_angles.shape[0]],    # pylint: disable=unsubscriptable-object
-        [0, 0])
+        [0, np.pi])
     _detuning_rotations = np.insert(
         _detuning_rotations,
         [0, _detuning_rotations.shape[0]],  # pylint: disable=unsubscriptable-object

--- a/tests/test_predefined_dynamical_decoupling.py
+++ b/tests/test_predefined_dynamical_decoupling.py
@@ -709,13 +709,13 @@ def test_if_uhrig_sequence_with_odd_pulses_is_identity():
     Tests if the product of the pulses in an Uhrig sequence with pre/post
     pi/2-pulses is an identity, when the number of pulses is odd.
     """
-    even_uhrig_sequence = new_predefined_dds(
+    odd_uhrig_sequence = new_predefined_dds(
         scheme=UHRIG_SINGLE_AXIS,
         duration=10.,
         number_of_offsets=7,
         pre_post_rotation=True)
 
-    assert _pulses_produce_identity(even_uhrig_sequence,
+    assert _pulses_produce_identity(odd_uhrig_sequence,
                                     expect_sigma_z=True)
 
 def test_if_uhrig_sequence_with_even_pulses_is_identity():

--- a/tests/test_predefined_dynamical_decoupling.py
+++ b/tests/test_predefined_dynamical_decoupling.py
@@ -805,7 +805,7 @@ def test_if_quadratic_sequence_with_odd_pulses_is_identity():
 
     # n_outer + n_inner*(n_outer+1) pi-pulses + 2 pi/2-pulses
     # total number here is odd
-    assert len(odd_quadratic_sequence.offsets) ==  7 + 7 * (7+1) + 2
+    assert len(odd_quadratic_sequence.offsets) == 7 + 7 * (7+1) + 2
 
     assert _pulses_produce_identity(odd_quadratic_sequence)
 

--- a/tests/test_predefined_dynamical_decoupling.py
+++ b/tests/test_predefined_dynamical_decoupling.py
@@ -583,7 +583,7 @@ def test_attribute_values():
             scheme=XY_CONCATENATED, duration=-2,
             concatenation_order=-1)
 
-def _pulses_produce_identity(sequence, expect_sigma_z=False):
+def _pulses_produce_identity(sequence):
     """
     Tests if the pulses of a DDS sequence produce an identity in absence of noise.
     We check this by creating the unitary of each pulse and then multiplying them
@@ -620,10 +620,6 @@ def _pulses_produce_identity(sequence, expect_sigma_z=False):
     matrix_product *= np.exp(-1.j* np.angle(matrix_product[0][0]))
 
     expected_matrix_product = np.identity(2)
-
-    # In case the expected output is sigma_z rather than identity
-    if expect_sigma_z:
-        expected_matrix_product = sigma_z
 
     return np.allclose(matrix_product, expected_matrix_product)
 
@@ -688,8 +684,7 @@ def test_if_cpmg_sequence_with_odd_pulses_is_identity():
         number_of_offsets=7,
         pre_post_rotation=True)
 
-    assert _pulses_produce_identity(odd_cpmg_sequence,
-                                    expect_sigma_z=True)
+    assert _pulses_produce_identity(odd_cpmg_sequence)
 
 def test_if_cpmg_sequence_with_even_pulses_is_identity():
     """
@@ -715,8 +710,7 @@ def test_if_uhrig_sequence_with_odd_pulses_is_identity():
         number_of_offsets=7,
         pre_post_rotation=True)
 
-    assert _pulses_produce_identity(odd_uhrig_sequence,
-                                    expect_sigma_z=True)
+    assert _pulses_produce_identity(odd_uhrig_sequence)
 
 def test_if_uhrig_sequence_with_even_pulses_is_identity():
     """
@@ -844,8 +838,7 @@ def test_if_quadratic_sequence_with_odd_inner_pulses_is_identity():
     # total number here is odd
     assert len(inner_odd_quadratic_sequence.offsets) == 8 + 7 * (8+1) + 2
 
-    assert _pulses_produce_identity(inner_odd_quadratic_sequence,
-                                    expect_sigma_z=True)
+    assert _pulses_produce_identity(inner_odd_quadratic_sequence)
 
 
 def test_if_quadratic_sequence_with_even_inner_pulses_is_identity():

--- a/tests/test_predefined_dynamical_decoupling.py
+++ b/tests/test_predefined_dynamical_decoupling.py
@@ -582,3 +582,291 @@ def test_attribute_values():
         _ = new_predefined_dds(
             scheme=XY_CONCATENATED, duration=-2,
             concatenation_order=-1)
+
+def _pulses_produce_identity(sequence, accept_sigma_z=False):
+    """
+    Tests if the pulses of a DDS sequence produce an identity in absence of noise.
+    We check this by creating the unitary of each pulse and then multiplying them
+    together to check their evolution
+    """
+    sigma_x = np.array([[0., 1.], [1., 0.]])
+    sigma_y = np.array([[0., -1.j], [1.j, 0.]])
+    sigma_z = np.array([[1., 0.], [0., -1.]])
+
+    # The unitary evolution due to an instantaneous pulse can be written as
+    # U = cos(|n|) I -i sin(|n|) *(n_x sigma_x + n_y sigma_y + n_z sigma_z)/|n|
+    # where n is a vector with components
+    # n_x = rabi * cos(azimuthal)/2
+    # n_y = rabi * sin(azimuthal)/2
+    # n_z = detuning/2
+
+    matrix_product = np.identity(2)
+    for rabi, azimuth, detuning in zip(sequence.rabi_rotations,
+                                       sequence.azimuthal_angles,
+                                       sequence.detuning_rotations):
+        n_x = rabi * np.cos(azimuth)/2.
+        n_y = rabi * np.sin(azimuth)/2.
+        n_z = detuning/2.
+        mod_n = np.sqrt(n_x**2 + n_y**2 + n_z**2)
+        unitary = (
+            np.cos(mod_n) * np.identity(2)
+            -1.j * (np.sin(mod_n)*n_x/mod_n) * sigma_x
+            -1.j * (np.sin(mod_n)*n_y/mod_n) * sigma_y
+            -1.j * (np.sin(mod_n)*n_z/mod_n) * sigma_z
+        )
+        matrix_product = np.matmul(unitary, matrix_product)
+
+    # Removes global phase
+    matrix_product *= np.exp(-1.j* np.angle(matrix_product[0][0]))
+
+    if accept_sigma_z:
+        print (matrix_product)
+        matrix_product[1][1] *= -1.
+
+    return np.allclose(matrix_product, np.identity(2))
+
+def test_if_ramsey_sequence_is_identity():
+    """
+    Tests if the product of the pulses in the Ramsey sequence with pre/post
+    pi/2-pulses is an identity.
+    """
+    ramsey_sequence = new_predefined_dds(
+        scheme='Ramsey',
+        duration=10.,
+        pre_post_rotation=True)
+
+    assert _pulses_produce_identity(ramsey_sequence)
+
+def test_if_spin_echo_sequence_is_identity():
+    """
+    Tests if the product of the pulses in a Spin Echo sequence with pre/post
+    pi/2-pulses is an identity.
+    """
+    spin_echo_sequence = new_predefined_dds(
+        scheme=SPIN_ECHO,
+        duration=10.,
+        pre_post_rotation=True)
+
+    assert _pulses_produce_identity(spin_echo_sequence)
+
+def test_if_carr_purcell_sequence_with_odd_pulses_is_identity():
+    """
+    Tests if the product of the pulses in a Carr-Purcell sequence with pre/post
+    pi/2-pulses is an identity, when the number of pulses is odd.
+    """
+    odd_carr_purcell_sequence = new_predefined_dds(
+        scheme=CARR_PURCELL,
+        duration=10.,
+        number_of_offsets=7,
+        pre_post_rotation=True)
+
+    assert _pulses_produce_identity(odd_carr_purcell_sequence)
+
+def test_if_carr_purcell_sequence_with_even_pulses_is_identity():
+    """
+    Tests if the product of the pulses in a Carr-Purcell sequence with pre/post
+    pi/2-pulses is an identity, when the number of pulses is even.
+    """
+    even_carr_purcell_sequence = new_predefined_dds(
+        scheme=CARR_PURCELL,
+        duration=10.,
+        number_of_offsets=8,
+        pre_post_rotation=True)
+
+    assert _pulses_produce_identity(even_carr_purcell_sequence)
+
+def test_if_cpmg_sequence_with_odd_pulses_is_identity():
+    """
+    Tests if the product of the pulses in a CPMG sequence with pre/post
+    pi/2-pulses is an identity, when the number of pulses is odd.
+    """
+    odd_cpmg_sequence = new_predefined_dds(
+        scheme=CARR_PURCELL_MEIBOOM_GILL,
+        duration=10.,
+        number_of_offsets=7,
+        pre_post_rotation=True)
+
+    assert _pulses_produce_identity(odd_cpmg_sequence,
+                                    accept_sigma_z=True)
+
+def test_if_cpmg_sequence_with_even_pulses_is_identity():
+    """
+    Tests if the product of the pulses in a CPMG sequence with pre/post
+    pi/2-pulses is an identity, when the number of pulses is even.
+    """
+    even_cpmg_sequence = new_predefined_dds(
+        scheme=CARR_PURCELL_MEIBOOM_GILL,
+        duration=10.,
+        number_of_offsets=8,
+        pre_post_rotation=True)
+
+    assert _pulses_produce_identity(even_cpmg_sequence)
+
+def test_if_uhrig_sequence_with_odd_pulses_is_identity():
+    """
+    Tests if the product of the pulses in a Uhrig sequence with pre/post
+    pi/2-pulses is an identity, when the number of pulses is odd.
+    """
+    even_uhrig_sequence = new_predefined_dds(
+        scheme=UHRIG_SINGLE_AXIS,
+        duration=10.,
+        number_of_offsets=7,
+        pre_post_rotation=True)
+
+    assert _pulses_produce_identity(even_uhrig_sequence,
+                                    accept_sigma_z=True)
+
+def test_if_uhrig_sequence_with_even_pulses_is_identity():
+    """
+    Tests if the product of the pulses in a Uhrig sequence with pre/post
+    pi/2-pulses is an identity, when the number of pulses is even.
+    """
+    even_uhrig_sequence = new_predefined_dds(
+        scheme=UHRIG_SINGLE_AXIS,
+        duration=10.,
+        number_of_offsets=8,
+        pre_post_rotation=True)
+
+    assert _pulses_produce_identity(even_uhrig_sequence)
+
+def test_if_periodic_sequence_with_odd_pulses_is_identity():
+    """
+    Tests if the product of the pulses in a periodic DDS with pre/post
+    pi/2-pulses is an identity, when the number of pulses is odd.
+    """
+    odd_periodic_sequence = new_predefined_dds(
+        scheme=PERIODIC_SINGLE_AXIS,
+        duration=10.,
+        number_of_offsets=7,
+        pre_post_rotation=True)
+
+    assert _pulses_produce_identity(odd_periodic_sequence)
+
+def test_if_periodic_sequence_with_even_pulses_is_identity():
+    """
+    Tests if the product of the pulses in a periodic DDS with pre/post
+    pi/2-pulses is an identity, when the number of pulses is even.
+    """
+    even_periodic_sequence = new_predefined_dds(
+        scheme=PERIODIC_SINGLE_AXIS,
+        duration=10.,
+        number_of_offsets=8,
+        pre_post_rotation=True)
+
+    assert _pulses_produce_identity(even_periodic_sequence)
+
+def test_if_walsh_sequence_with_odd_pulses_is_identity():
+    """
+    Tests if the product of the pulses in a Walsh sequence with pre/post
+    pi/2-pulses is an identity, when the number of pulses is odd.
+    """
+    odd_walsh_sequence = new_predefined_dds(
+        scheme=WALSH_SINGLE_AXIS,
+        duration=10.,
+        paley_order=7,
+        pre_post_rotation=True)
+
+    # A Walsh sequence with paley_order 7 has 5 pi-pulses + 2 pi/2-pulses,
+    # see https://arxiv.org/pdf/1109.6002.pdf
+    assert len(odd_walsh_sequence.offsets) == 5 + 2
+
+    assert _pulses_produce_identity(odd_walsh_sequence)
+
+def test_if_walsh_sequence_with_even_pulses_is_identity():
+    """
+    Tests if the product of the pulses in a quadratic sequence with pre/post
+    pi/2-pulses is an identity, when the number of pulses is even.
+    """
+    even_walsh_sequence = new_predefined_dds(
+        scheme=WALSH_SINGLE_AXIS,
+        duration=10.,
+        paley_order=6,
+        pre_post_rotation=True)
+
+    # A Walsh sequence with paley_order 7 has 4 pi-pulses + 2 pi/2-pulses,
+    # see https://arxiv.org/pdf/1109.6002.pdf
+    assert len(even_walsh_sequence.offsets) == 4 + 2
+
+    assert _pulses_produce_identity(even_walsh_sequence)
+
+def test_if_quadratic_sequence_with_odd_pulses_is_identity():
+    """
+    Tests if the product of the pulses in a quadratic sequence with pre/post
+    pi/2-pulses is an identity, when the total number of pulses is odd.
+    """
+    odd_quadratic_sequence = new_predefined_dds(
+        scheme=QUADRATIC,
+        duration=10.,
+        number_inner_offsets=7,
+        number_outer_offsets=7,
+        pre_post_rotation=True)
+
+    # n_outer + n_inner*(n_outer+1) pi-pulses + 2 pi/2-pulses
+    # total number here is odd
+    assert len(odd_quadratic_sequence.offsets) ==  7 + 7 * (7+1) + 2
+
+    assert _pulses_produce_identity(odd_quadratic_sequence)
+
+
+def test_if_quadratic_sequence_with_even_pulses_is_identity():
+    """
+    Tests if the product of the pulses in a quadratic sequence with pre/post
+    pi/2-pulses is an identity, when the total number of pulses is even.
+    """
+    even_quadratic_sequence = new_predefined_dds(
+        scheme=QUADRATIC,
+        duration=10.,
+        number_inner_offsets=8,
+        number_outer_offsets=8,
+        pre_post_rotation=True)
+
+    # n_outer + n_inner*(n_outer+1) pi-pulses + 2 pi/2-pulses
+    # total number here is even
+    assert len(even_quadratic_sequence.offsets) == 8 + 8 * (8+1) + 2
+
+    assert _pulses_produce_identity(even_quadratic_sequence)
+
+def test_if_quadratic_sequence_with_odd_inner_pulses_is_identity():
+    """
+    Tests if the product of the pulses in a quadratic sequence with pre/post
+    pi/2-pulses is an identity, when the total number of inner pulses is odd.
+    """
+    inner_odd_quadratic_sequence = new_predefined_dds(
+        scheme=QUADRATIC,
+        duration=10.,
+        number_inner_offsets=7,
+        number_outer_offsets=8,
+        pre_post_rotation=True)
+
+    # n_outer + n_inner*(n_outer+1) pi-pulses + 2 pi/2-pulses
+    # total number here is odd
+    assert len(inner_odd_quadratic_sequence.offsets) == 8 + 7 * (8+1) + 2
+
+    assert _pulses_produce_identity(inner_odd_quadratic_sequence,
+                                    accept_sigma_z=True)
+
+def test_if_x_concatenated_sequence_is_identity():
+    """
+    Tests if the product of the pulses in an X concatenated sequence with pre/post
+    pi/2-pulses is an identity.
+    """
+    x_concat_sequence = new_predefined_dds(
+        scheme=X_CONCATENATED,
+        duration=10.,
+        concatenation_order=4,
+        pre_post_rotation=True)
+
+    assert _pulses_produce_identity(x_concat_sequence)
+
+def test_if_xy_concatenated_sequence_is_identity():
+    """
+    Tests if the product of the pulses in an XY concatenated sequence with pre/post
+    pi/2-pulses is an identity.
+    """
+    xy_concat_sequence = new_predefined_dds(
+        scheme=XY_CONCATENATED,
+        duration=10.,
+        concatenation_order=4,
+        pre_post_rotation=True)
+
+    assert _pulses_produce_identity(xy_concat_sequence)

--- a/tests/test_predefined_dynamical_decoupling.py
+++ b/tests/test_predefined_dynamical_decoupling.py
@@ -853,7 +853,7 @@ def test_if_quadratic_sequence_with_even_inner_pulses_is_identity():
     Tests if the product of the pulses in a quadratic sequence with pre/post
     pi/2-pulses is an identity, when the total number of inner pulses is even.
     """
-    inner_odd_quadratic_sequence = new_predefined_dds(
+    inner_even_quadratic_sequence = new_predefined_dds(
         scheme=QUADRATIC,
         duration=10.,
         number_inner_offsets=8,
@@ -862,9 +862,9 @@ def test_if_quadratic_sequence_with_even_inner_pulses_is_identity():
 
     # n_outer + n_inner*(n_outer+1) pi-pulses + 2 pi/2-pulses
     # total number here is even
-    assert len(inner_odd_quadratic_sequence.offsets) == 7 + 8 * (7+1) + 2
+    assert len(inner_even_quadratic_sequence.offsets) == 7 + 8 * (7+1) + 2
 
-    assert _pulses_produce_identity(inner_odd_quadratic_sequence)
+    assert _pulses_produce_identity(inner_even_quadratic_sequence)
 
 def test_if_x_concatenated_sequence_is_identity():
     """


### PR DESCRIPTION
Fixes https://q-ctrl.atlassian.net/browse/QENG-716

The solution adopted is the one described in the ticket: we invert the direction of the final pi/2-pulse when necessary. I modified the current tests to expect these inverted pulses. I also added additional tests to check if every kind of DDS produces an identity (most of these tests fail if they are run in the current master branch).

Notice that in some cases the DDS produces sigma_z rather than the identity. This happens when there is an odd number of Y and Z pi-pulses in the DDS, and these situations are identified by `expect_sigma_z = True` in the tests. Notice that the sigma_z cannot be cancelled by X pulses.

Maybe this is not a problem, as the difference between an identity and a sigma_z is just a matter of reference frame in time. If this a problem, a straightforward solution would be to replace the X pi/2-pulses with Y pi/2-pulses in these situations. I can easily modify the code that.