### PR TITLE
Fixing detuning in DDS to control conversion

### DIFF
--- a/qctrlopencontrols/dynamic_decoupling_sequences/driven_controls.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/driven_controls.py
@@ -299,7 +299,7 @@ def convert_dds_to_driven_control(
             control_durations[pulse_segment_idx] = (pulse_start_ends[op_idx, 1] -
                                                     pulse_start_ends[op_idx, 0])
         else:
-            control_detunings[pulse_segment_idx] = operations[3, op_idx]
+            control_detunings[pulse_segment_idx] = maximum_detuning_rate
             control_durations[pulse_segment_idx] = (pulse_start_ends[op_idx, 1] -
                                                     pulse_start_ends[op_idx, 0])
 

--- a/tests/test_dynamical_decoupling.py
+++ b/tests/test_dynamical_decoupling.py
@@ -279,7 +279,7 @@ def test_conversion_to_driven_controls():
         [0., _azimuthal_angles[0], 0., 0., 0.,
          _azimuthal_angles[2], 0.]))
     assert np.allclose(driven_control.detunings, np.array(
-        [0., 0., 0., np.pi, 0., 0., 0]))
+        [0., 0., 0., _maximum_detuning_rate, 0., 0., 0]))
     assert np.allclose(driven_control.durations, np.array(
         [4.75e-1, 5e-2, 4.5e-1, 5e-2, 4.5e-1, 5e-2, 4.75e-1]))
 


### PR DESCRIPTION
Currently the DDS to control conversion sets the value of the detuning rates to be the same as the input detuning angle. However, the meaning of the `detunings` in the DrivenControls class is the detuning frequency rather than the detuning angle -- evidence of this is in the fact that the value of the detunings is compared to `UPPER_BOUND_DETUNING_RATE`, which is 1e10.

I'm fixing this by adopting the same procedure already used to convert the rabi_rotation into a rabi_frequency. Note that one of the unit tests had to be modified