### PR TITLE
Adding support to convert DDS with pi/2-pulses into controls

### DIFF
--- a/qctrlopencontrols/dynamic_decoupling_sequences/driven_controls.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/driven_controls.py
@@ -230,11 +230,11 @@ def convert_dds_to_driven_control(
 
             pulse_start_ends[op_idx, 1] = pulse_mid_points[op_idx] + half_pulse_duration
         else:
-            pulse_start_ends[op_idx, 0] = pulse_mid_points[op_idx] - \
-                                          0.5 * operations[3, op_idx] / maximum_detuning_rate
+            half_pulse_duration = 0.5 * np.abs(operations[3, op_idx]) / maximum_detuning_rate
 
-            pulse_start_ends[op_idx, 1] = pulse_mid_points[op_idx] + \
-                                          0.5 * operations[3, op_idx] / maximum_detuning_rate
+            pulse_start_ends[op_idx, 0] = pulse_mid_points[op_idx] - half_pulse_duration
+
+            pulse_start_ends[op_idx, 1] = pulse_mid_points[op_idx] + half_pulse_duration
 
     # check if any of the pulses have gone outside the time limit [0, sequence_duration]
     # if yes, adjust the segment timing
@@ -299,7 +299,11 @@ def convert_dds_to_driven_control(
             control_durations[pulse_segment_idx] = (pulse_start_ends[op_idx, 1] -
                                                     pulse_start_ends[op_idx, 0])
         else:
-            control_detunings[pulse_segment_idx] = maximum_detuning_rate
+            # detuning should be negative or positive depending on the direction of rotation
+            sign = np.sign(operations[3, op_idx])
+
+            control_detunings[pulse_segment_idx] = sign*maximum_detuning_rate
+
             control_durations[pulse_segment_idx] = (pulse_start_ends[op_idx, 1] -
                                                     pulse_start_ends[op_idx, 0])
 

--- a/tests/test_dynamical_decoupling.py
+++ b/tests/test_dynamical_decoupling.py
@@ -284,6 +284,46 @@ def test_conversion_to_driven_controls():
         [4.75e-1, 5e-2, 4.5e-1, 5e-2, 4.5e-1, 5e-2, 4.75e-1]))
 
 
+def test_conversion_of_pi_2_pulses_to_driven_controls():
+    """
+    Tests if the method to convert a DDS to driven controls handles properly
+    pi/2-pulses in the x, y, and z directions.
+    """
+    _duration = 6.
+    _offsets = np.array([0.5, 1.5, 2.5, 3.5, 4.5, 5.5])
+    _rabi_rotations = np.array([np.pi/2, 0., np.pi/2, np.pi/2, 0., np.pi/2])
+    _azimuthal_angles = np.array([np.pi / 2, 0., 0., -np.pi/2, 0, np.pi])
+    _detuning_rotations = np.array([0., np.pi/2, 0., 0., -np.pi/2, 0])
+    _name = 'pi2_pulse_sequence'
+
+    dd_sequence = DynamicDecouplingSequence(
+        duration=_duration,
+        offsets=_offsets,
+        rabi_rotations=_rabi_rotations,
+        azimuthal_angles=_azimuthal_angles,
+        detuning_rotations=_detuning_rotations,
+        name=_name)
+
+    _maximum_rabi_rate = 20*np.pi
+    _maximum_detuning_rate = 20*np.pi
+    driven_control = convert_dds_to_driven_control(dd_sequence,
+                                                   maximum_rabi_rate=_maximum_rabi_rate,
+                                                   maximum_detuning_rate=_maximum_detuning_rate,
+                                                   name=_name)
+
+    assert np.allclose(driven_control.rabi_rates, np.array(
+        [0., _maximum_rabi_rate, 0., 0., 0., _maximum_rabi_rate,
+         0., _maximum_rabi_rate, 0., 0., 0., _maximum_rabi_rate, 0.]))
+    assert np.allclose(driven_control.azimuthal_angles, np.array(
+        [0., _azimuthal_angles[0], 0., 0., 0., _azimuthal_angles[2],
+         0., _azimuthal_angles[3], 0., 0., 0., _azimuthal_angles[5], 0.]))
+    assert np.allclose(driven_control.detunings, np.array(
+        [0., 0., 0., _maximum_detuning_rate, 0., 0.,
+         0., 0., 0., -_maximum_detuning_rate, 0., 0., 0.]))
+    assert np.allclose(driven_control.durations, np.array(
+        [4.875e-1, 2.5e-2, 9.75e-1, 2.5e-2, 9.75e-1, 2.5e-2,
+         9.75e-1, 2.5e-2, 9.75e-1, 2.5e-2, 9.75e-1, 2.5e-2, 4.875e-1]))
+
 def test_free_evolution_conversion():
 
     """Tests the conversion of free evolution


### PR DESCRIPTION
I'm adding a test that tries to convert a sequence of pi/2-pulses into controls (Y, Z, and X pi/2-pulses, and then the same sequence but with negative rotation angles). This test currently fails in the master branch.

To solve the problem, I took two things into account:
1. As the value of the detuning angle can be negative, when we calculate the duration of a Z pulse, we have to use the absolute value of the detuning angle.
2. When the detuning angle is negative, the detuning rate used to generate the controls should also be negative.
With these two fixes, the tests pass.