### PR TITLE
Fixing conversion of a Y pi/2-pulse at the beginning of a DDS

### DIFF
--- a/qctrlopencontrols/dynamic_decoupling_sequences/driven_controls.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/driven_controls.py
@@ -217,9 +217,6 @@ def convert_dds_to_driven_control(
 
     for op_idx in range(operations.shape[1]):   # pylint: disable=unsubscriptable-object
 
-        if np.isclose(np.sum(operations[:, op_idx]), 0.0):
-            continue
-
         if operations[3, op_idx] == 0: #no z_rotations
             if not np.isclose(operations[1, op_idx], 0.):
                 half_pulse_duration = 0.5 * operations[1, op_idx] / maximum_rabi_rate

--- a/tests/test_dynamical_decoupling.py
+++ b/tests/test_dynamical_decoupling.py
@@ -324,6 +324,119 @@ def test_conversion_of_pi_2_pulses_to_driven_controls():
         [4.875e-1, 2.5e-2, 9.75e-1, 2.5e-2, 9.75e-1, 2.5e-2,
          9.75e-1, 2.5e-2, 9.75e-1, 2.5e-2, 9.75e-1, 2.5e-2, 4.875e-1]))
 
+
+def test_conversion_of_x_pi_2_pulses_at_extremities():
+    """
+    Tests if the method to convert a DDS to driven controls handles properly
+    X pi/2-pulses in inverse directions, in the beginning and end of the sequence.
+    """
+    _duration = 1.
+    _offsets = np.array([0., _duration])
+    _rabi_rotations = np.array([np.pi/2, np.pi/2])
+    _azimuthal_angles = np.array([np.pi, 0])
+    _detuning_rotations = np.array([0., 0])
+    _name = 'x_pi2_pulse_sequence'
+
+    dd_sequence = DynamicDecouplingSequence(
+        duration=_duration,
+        offsets=_offsets,
+        rabi_rotations=_rabi_rotations,
+        azimuthal_angles=_azimuthal_angles,
+        detuning_rotations=_detuning_rotations,
+        name=_name)
+
+    _maximum_rabi_rate = 20*np.pi
+    _maximum_detuning_rate = 20*np.pi
+    driven_control = convert_dds_to_driven_control(dd_sequence,
+                                                   maximum_rabi_rate=_maximum_rabi_rate,
+                                                   maximum_detuning_rate=_maximum_detuning_rate,
+                                                   name=_name)
+
+    assert np.allclose(driven_control.rabi_rates, np.array(
+        [_maximum_rabi_rate, 0., _maximum_rabi_rate]))
+    assert np.allclose(driven_control.azimuthal_angles, np.array(
+        [_azimuthal_angles[0], 0., _azimuthal_angles[1]]))
+    assert np.allclose(driven_control.detunings, np.array(
+        [0., 0., 0.]))
+    assert np.allclose(driven_control.durations, np.array(
+        [2.5e-2, _duration - 2* 2.5e-2, 2.5e-2]))
+
+
+def test_conversion_of_y_pi_2_pulses_at_extremities():
+    """
+    Tests if the method to convert a DDS to driven controls handles properly
+    Y pi/2-pulses in inverse directions, in the beginning and end of the sequence.
+    """
+    _duration = 1.
+    _offsets = np.array([0., _duration])
+    _rabi_rotations = np.array([np.pi/2, np.pi/2])
+    _azimuthal_angles = np.array([-np.pi/2, np.pi/2])
+    _detuning_rotations = np.array([0., 0])
+    _name = 'y_pi2_pulse_sequence'
+
+    dd_sequence = DynamicDecouplingSequence(
+        duration=_duration,
+        offsets=_offsets,
+        rabi_rotations=_rabi_rotations,
+        azimuthal_angles=_azimuthal_angles,
+        detuning_rotations=_detuning_rotations,
+        name=_name)
+
+    _maximum_rabi_rate = 20*np.pi
+    _maximum_detuning_rate = 20*np.pi
+    driven_control = convert_dds_to_driven_control(dd_sequence,
+                                                   maximum_rabi_rate=_maximum_rabi_rate,
+                                                   maximum_detuning_rate=_maximum_detuning_rate,
+                                                   name=_name)
+
+    assert np.allclose(driven_control.rabi_rates, np.array(
+        [_maximum_rabi_rate, 0., _maximum_rabi_rate]))
+    assert np.allclose(driven_control.azimuthal_angles, np.array(
+        [_azimuthal_angles[0], 0., _azimuthal_angles[1]]))
+    assert np.allclose(driven_control.detunings, np.array(
+        [0., 0., 0.]))
+    assert np.allclose(driven_control.durations, np.array(
+        [2.5e-2, _duration - 2* 2.5e-2, 2.5e-2]))
+
+
+
+def test_conversion_of_z_pi_2_pulses_at_extremities():
+    """
+    Tests if the method to convert a DDS to driven controls handles properly
+    Z pi/2-pulses in inverse directions, in the beginning and end of the sequence.
+    """
+    _duration = 1.
+    _offsets = np.array([0., _duration])
+    _rabi_rotations = np.array([0, 0])
+    _azimuthal_angles = np.array([0, 0])
+    _detuning_rotations = np.array([-np.pi/2, np.pi/2])
+    _name = 'z_pi2_pulse_sequence'
+
+    dd_sequence = DynamicDecouplingSequence(
+        duration=_duration,
+        offsets=_offsets,
+        rabi_rotations=_rabi_rotations,
+        azimuthal_angles=_azimuthal_angles,
+        detuning_rotations=_detuning_rotations,
+        name=_name)
+
+    _maximum_rabi_rate = 20*np.pi
+    _maximum_detuning_rate = 20*np.pi
+    driven_control = convert_dds_to_driven_control(dd_sequence,
+                                                   maximum_rabi_rate=_maximum_rabi_rate,
+                                                   maximum_detuning_rate=_maximum_detuning_rate,
+                                                   name=_name)
+
+    assert np.allclose(driven_control.rabi_rates, np.array(
+        [0, 0., 0]))
+    assert np.allclose(driven_control.azimuthal_angles, np.array(
+        [0, 0., 0]))
+    assert np.allclose(driven_control.detunings, np.array(
+        [-_maximum_detuning_rate, 0., _maximum_detuning_rate]))
+    assert np.allclose(driven_control.durations, np.array(
+        [2.5e-2, _duration - 2* 2.5e-2, 2.5e-2]))
+
+
 def test_free_evolution_conversion():
 
     """Tests the conversion of free evolution


### PR DESCRIPTION
I added tests for the conversion of DDS to DrivenControls of sequences containing pi/2-pulses at the beginning and end of their duration. The test for Y pi/2-pulses currently fails in the master branch.

The reason for this are two lines of code that skip the creation of a pulse if (offset + rabi angle + azimuthal angle + detuning angle) is zero. This is the case for a Y (-pi/2)-pulse at the beginning of the DDS: 0 + pi/2 + (-pi/2) + 0 = 0.

Removing those lines didn't seem to cause any new problem: all tests continue passing, including the  ones that check the conversion of a free evolution.