### PR TITLE
[QENG-714] Adding a minimum_segment_duration to DDS to controls converter

### DIFF
--- a/qctrlopencontrols/dynamic_decoupling_sequences/driven_controls.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/driven_controls.py
@@ -274,9 +274,9 @@ def convert_dds_to_driven_control(
                                           'deduced_pulse_end_timing': pulse_start_ends[:, 1]})
 
     # check if the minimum_segment_duration is respected in the gaps between the pulses
-    if not np.any(np.logical_or(np.greater(pulse_start_ends[1:, 0]-pulse_start_ends[:-1, 1],
-                                           minimum_segment_duration),
-                                np.isclose(pulse_start_ends[1:, 0], pulse_start_ends[:-1, 1]))):
+    gap_durations = pulse_start_ends[1:, 0] - pulse_start_ends[:-1, 1]
+    if not np.all(np.logical_or(np.greater(gap_durations, minimum_segment_duration),
+                                np.isclose(gap_durations, minimum_segment_duration))):
         raise ArgumentsValueError("Distance between pulses does not respect minimum_segment_duration. "
                                   "Try decreasing the minimum_segment_duration.",
                                   {'dynamic_decoupling_sequence': dynamic_decoupling_sequence,

--- a/qctrlopencontrols/dynamic_decoupling_sequences/driven_controls.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/driven_controls.py
@@ -274,8 +274,10 @@ def convert_dds_to_driven_control(
                                           'deduced_pulse_end_timing': pulse_start_ends[:, 1]})
 
     # check if the minimum_segment_duration is respected in the gaps between the pulses
-    if (np.any(pulse_start_ends[1:, 0]-pulse_start_ends[:-1, 1] < minimum_segment_duration)):
-        raise ArgumentsValueError("Distance between pulses does not respect minimum_segment_duration."
+    if not np.any(np.logical_or(np.greater(pulse_start_ends[1:, 0]-pulse_start_ends[:-1, 1],
+                                           minimum_segment_duration),
+                                np.isclose(pulse_start_ends[1:, 0], pulse_start_ends[:-1, 1]))):
+        raise ArgumentsValueError("Distance between pulses does not respect minimum_segment_duration. "
                                   "Try decreasing the minimum_segment_duration.",
                                   {'dynamic_decoupling_sequence': dynamic_decoupling_sequence,
                                    'maximum_rabi_rate': maximum_rabi_rate,

--- a/qctrlopencontrols/dynamic_decoupling_sequences/driven_controls.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/driven_controls.py
@@ -276,7 +276,7 @@ def convert_dds_to_driven_control(
     # check if the minimum_segment_duration is respected in the gaps between the pulses
     if (np.any(pulse_start_ends[1:, 0]-pulse_start_ends[:-1, 1] < minimum_segment_duration)):
         raise ArgumentsValueError("Distance between pulses does not respect minimum_segment_duration."
-                                  "Try increasing the  minimum_segment_duration.",
+                                  "Try decreasing the minimum_segment_duration.",
                                   {'dynamic_decoupling_sequence': dynamic_decoupling_sequence,
                                    'maximum_rabi_rate': maximum_rabi_rate,
                                    'maximum_detuning_rate': maximum_detuning_rate,
@@ -308,10 +308,10 @@ def convert_dds_to_driven_control(
         control_durations[pulse_segment_idx] = pulse_width
 
         if pulse_width > 0.:
-            if operations[3, op_idx] == 0.0:
+            if not np.isclose(operations[1, op_idx], 0.): # Rabi rotation
                 control_rabi_rates[pulse_segment_idx] = operations[1, op_idx]/pulse_width
                 control_azimuthal_angles[pulse_segment_idx] = operations[2, op_idx]
-            else:
+            elif not np.isclose(operations[3, op_idx], 0.): # Detuning rotation
                 control_detunings[pulse_segment_idx] = operations[3, op_idx]/pulse_width
 
         if op_idx != (operations.shape[1]-1):   # pylint: disable=unsubscriptable-object

--- a/qctrlopencontrols/dynamic_decoupling_sequences/driven_controls.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/driven_controls.py
@@ -109,8 +109,8 @@ def convert_dds_to_driven_control(
 
     Parameters
     ----------
-    dynamic_decoupling_sequence : qctrlopencontrols.DynamicDecouplingSequence, optional
-        The base DDS; Defaults to None
+    dynamic_decoupling_sequence : qctrlopencontrols.DynamicDecouplingSequence
+        The base DDS
     maximum_rabi_rate : float, optional
         Maximum Rabi Rate; Defaults to 2*pi
     maximum_detuning_rate : float, optional

--- a/tests/test_dynamical_decoupling.py
+++ b/tests/test_dynamical_decoupling.py
@@ -443,14 +443,11 @@ def test_conversion_of_pulses_with_arbitrary_rabi_rotations():
     Tests if the method to convert a DDS to driven controls handles properly
     Y pulses with rabi rotations that assume arbitrary values between 0 and pi.
     """
-    _number_of_pulses = 30
-    _duration = _number_of_pulses * 1.
-    _offsets = np.linspace(0.5, _duration-0.5, _number_of_pulses)
-    _rabi_rotations = np.pi/(_number_of_pulses+1)*np.linspace(1.,
-                                                              _number_of_pulses,
-                                                              _number_of_pulses)
-    _azimuthal_angles = np.repeat(np.pi/2., _number_of_pulses)
-    _detuning_rotations = np.repeat(0, _number_of_pulses)
+    _duration = 3.
+    _offsets = [0.5, 1.5, 2.5]
+    _rabi_rotations = [1., 2., 3.]
+    _azimuthal_angles = [np.pi/2, np.pi/2, np.pi/2]
+    _detuning_rotations = [0., 0., 0.]
     _name = 'arbitrary_rabi_rotation_sequence'
 
     dd_sequence = DynamicDecouplingSequence(
@@ -461,9 +458,9 @@ def test_conversion_of_pulses_with_arbitrary_rabi_rotations():
         detuning_rotations=_detuning_rotations,
         name=_name)
 
-    _maximum_rabi_rate = 20*np.pi
-    _maximum_detuning_rate = 10*np.pi
-    minimum_segment_duration = np.mean(_rabi_rotations/_maximum_rabi_rate)
+    _maximum_rabi_rate = 20
+    _maximum_detuning_rate = 10
+    minimum_segment_duration = 0.1
 
     driven_control = convert_dds_to_driven_control(dd_sequence,
                                                    maximum_rabi_rate=_maximum_rabi_rate,
@@ -471,30 +468,17 @@ def test_conversion_of_pulses_with_arbitrary_rabi_rotations():
                                                    minimum_segment_duration=minimum_segment_duration,
                                                    name=_name)
 
-    expected_rabi_rates = np.zeros(2*_number_of_pulses+1)
-
-    expected_azimuthal_angles = np.zeros(2*_number_of_pulses+1)
-    expected_azimuthal_angles[1::2] = _azimuthal_angles
-
-    expected_detuning_rates = np.zeros(2*_number_of_pulses+1)
-
-    pulse_durations = np.maximum(_rabi_rotations/_maximum_rabi_rate,
-                                 minimum_segment_duration)
-    expected_rabi_rates[1::2] = _rabi_rotations/pulse_durations
-
-    expected_durations = np.zeros(2*_number_of_pulses+1)
-    expected_durations[1::2] = pulse_durations
-    # durations of the middle gaps are: 1 - half of each of the neighboring pulses
-    expected_durations[2:-2:2] = 1. - 0.5*pulse_durations[:-1] - 0.5*pulse_durations[1:]
-    # initial and final gaps are just half of that
-    expected_durations[0] = 0.5 - 0.5*pulse_durations[0]
-    expected_durations[-1] = 0.5 - 0.5*pulse_durations[-1]
+    expected_rabi_rates = [0., 10., 0., 20., 0., 20., 0.]
+    expected_azimuthal_angles = [0., np.pi/2, 0., np.pi/2, 0., np.pi/2, 0.]
+    expected_detuning_rates = [0., 0., 0., 0., 0., 0., 0.]
+    expected_durations = [0.5 - 0.1/2, 0.1, 1. - 0.1/2 - 0.1/2, 0.1,
+                          1. - 0.1/2 - 0.15/2, 0.15, 0.5 - 0.15/2]
 
     assert np.allclose(driven_control.rabi_rates, expected_rabi_rates)
     assert np.allclose(driven_control.azimuthal_angles, expected_azimuthal_angles)
     assert np.allclose(driven_control.detunings, expected_detuning_rates)
     assert np.allclose(driven_control.durations, expected_durations)
-    
+
     # check explicitly that minimum segment duration is respected
     assert _all_greater_or_close(driven_control.duration, minimum_segment_duration)
 
@@ -505,14 +489,11 @@ def test_conversion_of_pulses_with_arbitrary_azimuthal_angles():
     Tests if the method to convert a DDS to driven controls handles properly
     pi-pulses with azimuthal angles that assume arbitrary values between 0 and pi/2.
     """
-    _number_of_pulses = 30
-    _duration = _number_of_pulses * 1.
-    _offsets = np.linspace(0.5, _duration-0.5, _number_of_pulses)
-    _rabi_rotations = np.repeat(np.pi, _number_of_pulses)
-    _azimuthal_angles = (np.pi/2)/(_number_of_pulses+1)*np.linspace(1.,
-                                                                    _number_of_pulses,
-                                                                    _number_of_pulses)
-    _detuning_rotations = np.repeat(0, _number_of_pulses)
+    _duration = 3.
+    _offsets = [0.5, 1.5, 2.5]
+    _rabi_rotations = [np.pi, np.pi, np.pi]
+    _azimuthal_angles = [0.5, 1., 1.5]
+    _detuning_rotations = [0., 0., 0.]
     _name = 'arbitrary_azimuthal_angle_sequence'
 
     dd_sequence = DynamicDecouplingSequence(
@@ -525,7 +506,7 @@ def test_conversion_of_pulses_with_arbitrary_azimuthal_angles():
 
     _maximum_rabi_rate = 20*np.pi
     _maximum_detuning_rate = 10*np.pi
-    minimum_segment_duration = np.mean(_rabi_rotations/_maximum_rabi_rate)
+    minimum_segment_duration = 0.1
 
     driven_control = convert_dds_to_driven_control(dd_sequence,
                                                    maximum_rabi_rate=_maximum_rabi_rate,
@@ -533,24 +514,11 @@ def test_conversion_of_pulses_with_arbitrary_azimuthal_angles():
                                                    minimum_segment_duration=minimum_segment_duration,
                                                    name=_name)
 
-    expected_rabi_rates = np.zeros(2*_number_of_pulses+1)
-
-    expected_azimuthal_angles = np.zeros(2*_number_of_pulses+1)
-    expected_azimuthal_angles[1::2] = _azimuthal_angles
-
-    expected_detuning_rates = np.zeros(2*_number_of_pulses+1)
-
-    pulse_durations = np.maximum(_rabi_rotations/_maximum_rabi_rate,
-                                 minimum_segment_duration)
-    expected_rabi_rates[1::2] = _rabi_rotations/pulse_durations
-
-    expected_durations = np.zeros(2*_number_of_pulses+1)
-    expected_durations[1::2] = pulse_durations
-    # durations of the middle gaps are: 1 - half of each of the neighboring pulses
-    expected_durations[2:-2:2] = 1. - 0.5*pulse_durations[:-1] - 0.5*pulse_durations[1:]
-    # initial and final gaps are just half of that
-    expected_durations[0] = 0.5 - 0.5*pulse_durations[0]
-    expected_durations[-1] = 0.5 - 0.5*pulse_durations[-1]
+    expected_rabi_rates = [0., 10.*np.pi, 0., 10.*np.pi, 0., 10.*np.pi, 0.]
+    expected_azimuthal_angles = [0., 0.5, 0., 1.0, 0., 1.5, 0.]
+    expected_detuning_rates = [0., 0., 0., 0., 0., 0., 0.]
+    expected_durations = [0.5 - 0.1/2, 0.1, 1. - 0.1/2 - 0.1/2, 0.1,
+                          1. - 0.1/2 - 0.1/2, 0.1, 0.5 - 0.1/2]
 
     assert np.allclose(driven_control.rabi_rates, expected_rabi_rates)
     assert np.allclose(driven_control.azimuthal_angles, expected_azimuthal_angles)
@@ -567,14 +535,11 @@ def test_conversion_of_pulses_with_arbitrary_detuning_rotations():
     Tests if the method to convert a DDS to driven controls handles properly
     Z pulses with detuning rotations that assume arbitrary values between 0 and pi.
     """
-    _number_of_pulses = 10
-    _duration = _number_of_pulses * 1.
-    _offsets = np.linspace(0.5, _duration-0.5, _number_of_pulses)
-    _rabi_rotations = np.repeat(0., _number_of_pulses)
-    _azimuthal_angles = np.repeat(0., _number_of_pulses)
-    _detuning_rotations = np.pi/(_number_of_pulses+1)*np.linspace(1.,
-                                                                  _number_of_pulses,
-                                                                  _number_of_pulses)
+    _duration = 3.
+    _offsets = [0.5, 1.5, 2.5]
+    _rabi_rotations = [0., 0., 0.]
+    _azimuthal_angles = [0., 0., 0.]
+    _detuning_rotations = [1., 2., 3.]
     _name = 'arbitrary_detuning_rotation_sequence'
 
     dd_sequence = DynamicDecouplingSequence(
@@ -585,9 +550,9 @@ def test_conversion_of_pulses_with_arbitrary_detuning_rotations():
         detuning_rotations=_detuning_rotations,
         name=_name)
 
-    _maximum_rabi_rate = 20*np.pi
-    _maximum_detuning_rate = 10*np.pi
-    minimum_segment_duration = np.mean(_detuning_rotations/_maximum_detuning_rate)
+    _maximum_rabi_rate = 20
+    _maximum_detuning_rate = 10
+    minimum_segment_duration = 0.2
 
     driven_control = convert_dds_to_driven_control(dd_sequence,
                                                    maximum_rabi_rate=_maximum_rabi_rate,
@@ -595,24 +560,11 @@ def test_conversion_of_pulses_with_arbitrary_detuning_rotations():
                                                    minimum_segment_duration=minimum_segment_duration,
                                                    name=_name)
 
-    expected_rabi_rates = np.zeros(2*_number_of_pulses+1)
-
-    expected_azimuthal_angles = np.zeros(2*_number_of_pulses+1)
-    expected_azimuthal_angles[1::2] = _azimuthal_angles
-
-    expected_detuning_rates = np.zeros(2*_number_of_pulses+1)
-
-    pulse_durations = np.maximum(minimum_segment_duration,
-                                 _detuning_rotations/_maximum_detuning_rate)
-    expected_detuning_rates[1::2] = _detuning_rotations/pulse_durations
-
-    expected_durations = np.zeros(2*_number_of_pulses+1)
-    expected_durations[1::2] = pulse_durations
-    # durations of the middle gaps are: 1 - half of each of the neighboring pulses
-    expected_durations[2:-2:2] = 1. - 0.5*pulse_durations[:-1] - 0.5*pulse_durations[1:]
-    # initial and final gaps are just half of that
-    expected_durations[0] = 0.5 - 0.5*pulse_durations[0]
-    expected_durations[-1] = 0.5 - 0.5*pulse_durations[-1]
+    expected_rabi_rates = [0., 0., 0., 0., 0., 0., 0.]
+    expected_azimuthal_angles = [0., 0., 0., 0., 0., 0., 0.]
+    expected_detuning_rates = [0., 5., 0., 10., 0., 10., 0.]
+    expected_durations = [0.5 - 0.2/2, 0.2, 1. - 0.2/2 - 0.2/2, 0.2,
+                          1. - 0.2/2 - 0.3/2, 0.3, 0.5 - 0.3/2]
 
     assert np.allclose(driven_control.rabi_rates, expected_rabi_rates)
     assert np.allclose(driven_control.azimuthal_angles, expected_azimuthal_angles)

--- a/tests/test_dynamical_decoupling.py
+++ b/tests/test_dynamical_decoupling.py
@@ -279,9 +279,11 @@ def test_conversion_to_driven_controls():
         [0., _azimuthal_angles[0], 0., 0., 0.,
          _azimuthal_angles[2], 0.]))
     assert np.allclose(driven_control.detunings, np.array(
-        [0., 0., 0., np.pi, 0., 0., 0]))
+        [0., 0., 0., _maximum_detuning_rate, 0., 0., 0]))
     assert np.allclose(driven_control.durations, np.array(
         [4.75e-1, 5e-2, 4.5e-1, 5e-2, 4.5e-1, 5e-2, 4.75e-1]))
+
+
 
 
 def test_free_evolution_conversion():

--- a/tests/test_dynamical_decoupling.py
+++ b/tests/test_dynamical_decoupling.py
@@ -494,6 +494,9 @@ def test_conversion_of_pulses_with_arbitrary_rabi_rotations():
     assert np.allclose(driven_control.azimuthal_angles, expected_azimuthal_angles)
     assert np.allclose(driven_control.detunings, expected_detuning_rates)
     assert np.allclose(driven_control.durations, expected_durations)
+    
+    # check explicitly that minimum segment duration is respected
+    assert _all_greater_or_close(driven_control.duration, minimum_segment_duration)
 
 
 
@@ -554,6 +557,9 @@ def test_conversion_of_pulses_with_arbitrary_azimuthal_angles():
     assert np.allclose(driven_control.detunings, expected_detuning_rates)
     assert np.allclose(driven_control.durations, expected_durations)
 
+    # check explicitly that minimum segment duration is respected
+    assert _all_greater_or_close(driven_control.duration, minimum_segment_duration)
+
 
 
 def test_conversion_of_pulses_with_arbitrary_detuning_rotations():
@@ -608,12 +614,14 @@ def test_conversion_of_pulses_with_arbitrary_detuning_rotations():
     expected_durations[0] = 0.5 - 0.5*pulse_durations[0]
     expected_durations[-1] = 0.5 - 0.5*pulse_durations[-1]
 
-    print (driven_control.durations)
-    print (driven_control.detunings)
     assert np.allclose(driven_control.rabi_rates, expected_rabi_rates)
     assert np.allclose(driven_control.azimuthal_angles, expected_azimuthal_angles)
     assert np.allclose(driven_control.detunings, expected_detuning_rates)
     assert np.allclose(driven_control.durations, expected_durations)
+
+    # check explicitly that minimum segment duration is respected
+    assert _all_greater_or_close(driven_control.duration, minimum_segment_duration)
+
 
 
 def test_free_evolution_conversion():
@@ -749,6 +757,14 @@ def test_export_to_file():
     _remove_file('dds_qctrl_cylindrical.json')
     _remove_file('dds_qctrl_cartesian.json')
 
+
+def _all_greater_or_close(array, value):
+    """
+    Returns True if array is greater or close to value, element-wise.
+    """
+    return np.all(
+        np.logical_or(np.greater_equal(array, value), np.isclose(array, value))
+    )
 
 if __name__ == '__main__':
     pass


### PR DESCRIPTION
Partially fixes
https://q-ctrl.atlassian.net/browse/QENG-714

and was sparked by the discussion in 
https://github.com/qctrl/python-core/pull/322

I added an optional `minimum_segment_duration` to the DDS -> DrivenControls converter. The idea is: if the pulse duration estimated from the maximum frequency is smaller than the minimum segment value selected, then the `minimum_segment_duration` is used instead. The amplitudes of the controls are then calculated from the total rotation we want to achieve and the duration of the pulse, rather than always taking the maximum possible value.

I was maybe a bit conservative in these changes, and didn't touch other aspects of this function, such as the requirement that no pulse can simultaneously have Rabi and detuning rotations (alhtough I added a line in docstring to make this requirement explicit). We might want to create a ticket for a new feature supporting arbitrary rotation axes, though.

I also added three new tests in which I convert pulses with various values of the Rabi rotation, azimuthal angle, and detuning rotation. I always set the minimum_segment_duration to be the average size of those pulses, to make sure the duration of at least half of them should be affected by the new feature.
