### PR TITLE
Making sure all half_pulse_durations are positive

### DIFF
--- a/qctrlopencontrols/dynamic_decoupling_sequences/driven_controls.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/driven_controls.py
@@ -231,20 +231,12 @@ def convert_dds_to_driven_control(
     # check if any of the pulses have gone outside the time limit [0, sequence_duration]
     # if yes, adjust the segment timing
     if pulse_start_ends[0, 0] < 0.:
-
-        if np.sum(np.abs(pulse_start_ends[0, :])) == 0:
-            pulse_start_ends[0, 0] = 0
-        else:
-            translation = 0. - (pulse_start_ends[0, 0])
-            pulse_start_ends[0, :] = pulse_start_ends[0, :] + translation
+        translation = 0. - (pulse_start_ends[0, 0])
+        pulse_start_ends[0, :] = pulse_start_ends[0, :] + translation
 
     if pulse_start_ends[-1, 1] > sequence_duration:
-
-        if np.sum(np.abs(pulse_start_ends[0, :])) == 2 * sequence_duration:
-            pulse_start_ends[-1, 1] = sequence_duration
-        else:
-            translation = pulse_start_ends[-1, 1] - sequence_duration
-            pulse_start_ends[-1, :] = pulse_start_ends[-1, :] - translation
+        translation = pulse_start_ends[-1, 1] - sequence_duration
+        pulse_start_ends[-1, :] = pulse_start_ends[-1, :] - translation
 
     # four conditions to check
     # 1. Control segment start times should be monotonically increasing

--- a/qctrlopencontrols/dynamic_decoupling_sequences/driven_controls.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/driven_controls.py
@@ -238,7 +238,7 @@ def convert_dds_to_driven_control(
         translation = pulse_start_ends[-1, 1] - sequence_duration
         pulse_start_ends[-1, :] = pulse_start_ends[-1, :] - translation
 
-    # four conditions to check
+    # three conditions to check
     # 1. Control segment start times should be monotonically increasing
     # 2. Control segment end times should be monotonically increasing
     # 3. Adjacent segments should not be overlapping

--- a/qctrlopencontrols/dynamic_decoupling_sequences/driven_controls.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/driven_controls.py
@@ -173,6 +173,12 @@ def convert_dds_to_driven_control(
     azimuthal_angles = dynamic_decoupling_sequence.azimuthal_angles
     detuning_rotations = dynamic_decoupling_sequence.detuning_rotations
 
+    # check if all Rabi rotations are valid (i.e. have positive values)
+    if np.any(np.less(rabi_rotations, 0.)):
+        raise ArgumentsValueError(
+            'Sequence contains negative values for Rabi rotations.',
+            {'dynamic_decoupling_sequence': str(dynamic_decoupling_sequence)})
+
     # check for valid operation
     if not _check_valid_operation(rabi_rotations=rabi_rotations,
                                   detuning_rotations=detuning_rotations):
@@ -219,7 +225,7 @@ def convert_dds_to_driven_control(
         half_pulse_duration  = 0.
 
         if not np.isclose(operations[1, op_idx], 0.): # Rabi rotation
-            half_pulse_duration = 0.5 * max(np.abs(operations[1, op_idx]) / maximum_rabi_rate,
+            half_pulse_duration = 0.5 * max(operations[1, op_idx] / maximum_rabi_rate,
                                             minimum_segment_duration)
         elif not np.isclose(operations[3, op_idx], 0.): # Detuning rotation
             half_pulse_duration = 0.5 * max(np.abs(operations[3, op_idx]) / maximum_detuning_rate,

--- a/qctrlopencontrols/dynamic_decoupling_sequences/driven_controls.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/driven_controls.py
@@ -77,17 +77,17 @@ def _check_maximum_rotation_rate(
     """
 
     # check against global parameters
-    if maximum_rabi_rate < 0. or maximum_rabi_rate > UPPER_BOUND_RABI_RATE:
+    if maximum_rabi_rate <= 0. or maximum_rabi_rate > UPPER_BOUND_RABI_RATE:
         raise ArgumentsValueError(
-            'Maximum rabi rate must be between 0. and maximum value of {0}'.format(
+            'Maximum rabi rate must be greater than 0. and less or equal to {0}'.format(
                 UPPER_BOUND_RABI_RATE),
             {'maximum_rabi_rate': maximum_rabi_rate},
             extras={'maximum_detuning_rate': maximum_detuning_rate,
                     'allowed_maximum_rabi_rate': UPPER_BOUND_RABI_RATE})
 
-    if maximum_detuning_rate < 0. or maximum_detuning_rate > UPPER_BOUND_DETUNING_RATE:
+    if maximum_detuning_rate <= 0. or maximum_detuning_rate > UPPER_BOUND_DETUNING_RATE:
         raise ArgumentsValueError(
-            'Maximum detuning rate must be between 0. and maximum value of {0}'.format(
+            'Maximum detuning rate must be greater than 0. and less or equalt o {0}'.format(
                 UPPER_BOUND_DETUNING_RATE),
             {'maximum_detuning_rate': maximum_detuning_rate, },
             extras={'maximum_rabi_rate': maximum_rabi_rate,
@@ -112,9 +112,9 @@ def convert_dds_to_driven_control(
     dynamic_decoupling_sequence : qctrlopencontrols.DynamicDecouplingSequence
         The base DDS
     maximum_rabi_rate : float, optional
-        Maximum Rabi Rate; Defaults to 2*pi
+        Maximum Rabi Rate. Defaults to 2*pi, and must be greater than 0 if set.
     maximum_detuning_rate : float, optional
-        Maximum Detuning Rate; Defaults to 2*pi
+        Maximum Detuning Rate; Defaults to 2*pi, and must be greater than 0 if set.
     minimum_segment_duration : float, optional
         If set, further restricts the duration of every segment of the Driven Controls.
         Defaults to 0, in which case it does not affect the duration of the pulses.
@@ -182,15 +182,6 @@ def convert_dds_to_driven_control(
             extras={'maximum_rabi_rate': maximum_rabi_rate,
                     'maximum_detuning_rate': maximum_detuning_rate})
 
-    # check if detuning rate is supplied if there is a detuning_rotation > 0
-    if np.any(detuning_rotations > 0.) and maximum_detuning_rate is None:
-        raise ArgumentsValueError(
-            'Sequence operation includes detuning rotations. Please supply a valid '
-            'maximum_detuning_rate.',
-            {'detuning_rotations': dynamic_decoupling_sequence.detuning_rotations,
-             'maximum_detuning_rate': maximum_detuning_rate},
-            extras={'maximum_rabi_rate': maximum_rabi_rate})
-
     if offsets.size == 0:
         offsets = np.array([0, sequence_duration])
         rabi_rotations = np.array([0, 0])
@@ -227,7 +218,7 @@ def convert_dds_to_driven_control(
         half_pulse_duration  = 0.
 
         if not np.isclose(operations[1, op_idx], 0.): # Rabi rotation
-            half_pulse_duration = 0.5 * max(operations[1, op_idx] / maximum_rabi_rate,
+            half_pulse_duration = 0.5 * max(np.abs(operations[1, op_idx]) / maximum_rabi_rate,
                                             minimum_segment_duration)
         elif not np.isclose(operations[3, op_idx], 0.): # Detuning rotation
             half_pulse_duration = 0.5 * max(np.abs(operations[3, op_idx]) / maximum_detuning_rate,
@@ -257,11 +248,9 @@ def convert_dds_to_driven_control(
     # four conditions to check
     # 1. Control segment start times should be monotonically increasing
     # 2. Control segment end times should be monotonically increasing
-    # 3. Control segment start time must be less than its end time
-    # 4. Adjacent segments should not be overlapping
+    # 3. Adjacent segments should not be overlapping
     if (np.any(pulse_start_ends[0:-1, 0] - pulse_start_ends[1:, 0] > 0.) or
             np.any(pulse_start_ends[0:-1, 1] - pulse_start_ends[1:, 1] > 0.) or
-            np.any(pulse_start_ends[:, 0] - pulse_start_ends[:, 1] > 0.) or
             np.any(pulse_start_ends[1:, 0]-pulse_start_ends[0:-1, 1] < 0.)):
 
         raise ArgumentsValueError('Pulse timing could not be properly deduced from '
@@ -284,7 +273,8 @@ def convert_dds_to_driven_control(
                                    'maximum_detuning_rate': maximum_detuning_rate,
                                    'minimum_segment_duration': minimum_segment_duration},
                                   extras={'deduced_pulse_start_timing': pulse_start_ends[:, 0],
-                                          'deduced_pulse_end_timing': pulse_start_ends[:, 1]})
+                                          'deduced_pulse_end_timing': pulse_start_ends[:, 1],
+                                          'gap_durations': gap_durations})
 
 
     if np.allclose(pulse_start_ends, 0.0):

--- a/qctrlopencontrols/dynamic_decoupling_sequences/driven_controls.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/driven_controls.py
@@ -79,7 +79,7 @@ def _check_maximum_rotation_rate(
     # check against global parameters
     if maximum_rabi_rate <= 0. or maximum_rabi_rate > UPPER_BOUND_RABI_RATE:
         raise ArgumentsValueError(
-            'Maximum rabi rate must be greater than 0. and less or equal to {0}'.format(
+            'Maximum rabi rate must be greater than 0 and less or equal to {0}'.format(
                 UPPER_BOUND_RABI_RATE),
             {'maximum_rabi_rate': maximum_rabi_rate},
             extras={'maximum_detuning_rate': maximum_detuning_rate,
@@ -87,11 +87,10 @@ def _check_maximum_rotation_rate(
 
     if maximum_detuning_rate <= 0. or maximum_detuning_rate > UPPER_BOUND_DETUNING_RATE:
         raise ArgumentsValueError(
-            'Maximum detuning rate must be greater than 0. and less or equalt o {0}'.format(
+            'Maximum detuning rate must be greater than 0 and less or equal to {0}'.format(
                 UPPER_BOUND_DETUNING_RATE),
             {'maximum_detuning_rate': maximum_detuning_rate, },
             extras={'maximum_rabi_rate': maximum_rabi_rate,
-                    'allowed_maximum_rabi_rate': UPPER_BOUND_RABI_RATE,
                     'allowed_maximum_detuning_rate': UPPER_BOUND_DETUNING_RATE})
 
 
@@ -112,9 +111,11 @@ def convert_dds_to_driven_control(
     dynamic_decoupling_sequence : qctrlopencontrols.DynamicDecouplingSequence
         The base DDS
     maximum_rabi_rate : float, optional
-        Maximum Rabi Rate. Defaults to 2*pi, and must be greater than 0 if set.
+        Maximum Rabi Rate; Defaults to 2*pi.
+        Must be greater than 0 and less or equal to UPPER_BOUND_RABI_RATE, if set.
     maximum_detuning_rate : float, optional
-        Maximum Detuning Rate; Defaults to 2*pi, and must be greater than 0 if set.
+        Maximum Detuning Rate; Defaults to 2*pi.
+        Must be greater than 0 and less or equal to UPPER_BOUND_DETUNING_RATE, if set.
     minimum_segment_duration : float, optional
         If set, further restricts the duration of every segment of the Driven Controls.
         Defaults to 0, in which case it does not affect the duration of the pulses.


### PR DESCRIPTION
This is the first step towards simplifying and making the argument check mentioned in the following comment more floating-point friendly:
https://github.com/qctrl/python-open-controls/pull/67#discussion_r400668817
in order to solve Luigi's bug.

This PR eliminates the need of checking whether all the pulse starts are smaller or equal to the pulse ends, by making sure that all the `half_pulse_duration` are positive. This is done in two parts:

1. Making sure we take the absolute value of the Rabi rotation when calculating the `half_pulse_duration`. In principle this should be a positive value, but lacking any prior test there might be nothing stopping the user to try to set it as -pi/2 as a way to obtain a (-pi/2)-pulse in the X direction, for example. (The proper way to do that would be to set the Rabi rotation as pi/2 and the azimuthal angle as pi.)

2. Making sure `maximum_rabi_rate` and `maximum_detuning_rate` are not zero, or we would be dividing by zero and obtaining infinite durations for the pulses. This is done by updating the `_check_maximum_rotation_rate` private function.

After this, the `pulse_start_ends` is only updated by adding the same translation value to the start and the end of the pulse, so there shouldn't be any case where the start and end points switch positions. The only two exceptions were:
1. If the start of the first pulse is less than zero and the sum of the modulus of the start and the modulus of the end of the first pulse is zero.
2. If the end of the last pulse is greater than the duration of the sequence and the first pulse is centered around the the end of the sequence.

The first case is a logic contradiction, so it would never occur. I can't imagine why the second case  is meaningful (if you have two pulses at the origin for a sequence of duration zero, the translation procedure should still work), so I've eliminated it as well.

Finally, I realized that if someone sets `maximum_detuning_rate = None` the `_check_maximum_rotation_rate()` fails, so the check for `if maximum_detuning_rate is None` is never activated, so I've eliminated it as well.