### PR TITLE
Making the errors in DDS to Controls conversion more floating-point-friendly

### DIFF
--- a/qctrlopencontrols/dynamic_decoupling_sequences/driven_controls.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/driven_controls.py
@@ -231,20 +231,12 @@ def convert_dds_to_driven_control(
     # check if any of the pulses have gone outside the time limit [0, sequence_duration]
     # if yes, adjust the segment timing
     if pulse_start_ends[0, 0] < 0.:
-
-        if np.sum(np.abs(pulse_start_ends[0, :])) == 0:
-            pulse_start_ends[0, 0] = 0
-        else:
-            translation = 0. - (pulse_start_ends[0, 0])
-            pulse_start_ends[0, :] = pulse_start_ends[0, :] + translation
+        translation = 0. - (pulse_start_ends[0, 0])
+        pulse_start_ends[0, :] = pulse_start_ends[0, :] + translation
 
     if pulse_start_ends[-1, 1] > sequence_duration:
-
-        if np.sum(np.abs(pulse_start_ends[0, :])) == 2 * sequence_duration:
-            pulse_start_ends[-1, 1] = sequence_duration
-        else:
-            translation = pulse_start_ends[-1, 1] - sequence_duration
-            pulse_start_ends[-1, :] = pulse_start_ends[-1, :] - translation
+        translation = pulse_start_ends[-1, 1] - sequence_duration
+        pulse_start_ends[-1, :] = pulse_start_ends[-1, :] - translation
 
     # four conditions to check
     # 1. Control segment start times should be monotonically increasing

--- a/qctrlopencontrols/dynamic_decoupling_sequences/driven_controls.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/driven_controls.py
@@ -214,7 +214,7 @@ def convert_dds_to_driven_control(
     # check that the offsets are correctly sorted in time
     if any(np.diff(offsets) <= 0.):
         raise ArgumentsValueError("Pulse timing could not be properly deduced from "
-                                  "the sequence offsets. Make sure all offset are "
+                                  "the sequence offsets. Make sure all offsets are "
                                   "in increasing order.",
                                   {'dynamic_decoupling_sequence': dynamic_decoupling_sequence},
                                   extras={'offsets': offsets})

--- a/qctrlopencontrols/dynamic_decoupling_sequences/driven_controls.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/driven_controls.py
@@ -77,17 +77,17 @@ def _check_maximum_rotation_rate(
     """
 
     # check against global parameters
-    if maximum_rabi_rate < 0. or maximum_rabi_rate > UPPER_BOUND_RABI_RATE:
+    if maximum_rabi_rate <= 0. or maximum_rabi_rate > UPPER_BOUND_RABI_RATE:
         raise ArgumentsValueError(
-            'Maximum rabi rate must be between 0. and maximum value of {0}'.format(
+            'Maximum rabi rate must be greater than 0. and less or equal to {0}'.format(
                 UPPER_BOUND_RABI_RATE),
             {'maximum_rabi_rate': maximum_rabi_rate},
             extras={'maximum_detuning_rate': maximum_detuning_rate,
                     'allowed_maximum_rabi_rate': UPPER_BOUND_RABI_RATE})
 
-    if maximum_detuning_rate < 0. or maximum_detuning_rate > UPPER_BOUND_DETUNING_RATE:
+    if maximum_detuning_rate <= 0. or maximum_detuning_rate > UPPER_BOUND_DETUNING_RATE:
         raise ArgumentsValueError(
-            'Maximum detuning rate must be between 0. and maximum value of {0}'.format(
+            'Maximum detuning rate must be greater than 0. and less or equalt o {0}'.format(
                 UPPER_BOUND_DETUNING_RATE),
             {'maximum_detuning_rate': maximum_detuning_rate, },
             extras={'maximum_rabi_rate': maximum_rabi_rate,
@@ -112,9 +112,9 @@ def convert_dds_to_driven_control(
     dynamic_decoupling_sequence : qctrlopencontrols.DynamicDecouplingSequence
         The base DDS
     maximum_rabi_rate : float, optional
-        Maximum Rabi Rate; Defaults to 2*pi
+        Maximum Rabi Rate. Defaults to 2*pi, and must be greater than 0 if set.
     maximum_detuning_rate : float, optional
-        Maximum Detuning Rate; Defaults to 2*pi
+        Maximum Detuning Rate; Defaults to 2*pi, and must be greater than 0 if set.
     minimum_segment_duration : float, optional
         If set, further restricts the duration of every segment of the Driven Controls.
         Defaults to 0, in which case it does not affect the duration of the pulses.
@@ -182,15 +182,6 @@ def convert_dds_to_driven_control(
             extras={'maximum_rabi_rate': maximum_rabi_rate,
                     'maximum_detuning_rate': maximum_detuning_rate})
 
-    # check if detuning rate is supplied if there is a detuning_rotation > 0
-    if np.any(detuning_rotations > 0.) and maximum_detuning_rate is None:
-        raise ArgumentsValueError(
-            'Sequence operation includes detuning rotations. Please supply a valid '
-            'maximum_detuning_rate.',
-            {'detuning_rotations': dynamic_decoupling_sequence.detuning_rotations,
-             'maximum_detuning_rate': maximum_detuning_rate},
-            extras={'maximum_rabi_rate': maximum_rabi_rate})
-
     if offsets.size == 0:
         offsets = np.array([0, sequence_duration])
         rabi_rotations = np.array([0, 0])
@@ -227,7 +218,7 @@ def convert_dds_to_driven_control(
         half_pulse_duration  = 0.
 
         if not np.isclose(operations[1, op_idx], 0.): # Rabi rotation
-            half_pulse_duration = 0.5 * max(operations[1, op_idx] / maximum_rabi_rate,
+            half_pulse_duration = 0.5 * max(np.abs(operations[1, op_idx]) / maximum_rabi_rate,
                                             minimum_segment_duration)
         elif not np.isclose(operations[3, op_idx], 0.): # Detuning rotation
             half_pulse_duration = 0.5 * max(np.abs(operations[3, op_idx]) / maximum_detuning_rate,
@@ -257,11 +248,9 @@ def convert_dds_to_driven_control(
     # four conditions to check
     # 1. Control segment start times should be monotonically increasing
     # 2. Control segment end times should be monotonically increasing
-    # 3. Control segment start time must be less than its end time
-    # 4. Adjacent segments should not be overlapping
+    # 3. Adjacent segments should not be overlapping
     if (np.any(pulse_start_ends[0:-1, 0] - pulse_start_ends[1:, 0] > 0.) or
             np.any(pulse_start_ends[0:-1, 1] - pulse_start_ends[1:, 1] > 0.) or
-            np.any(pulse_start_ends[:, 0] - pulse_start_ends[:, 1] > 0.) or
             np.any(pulse_start_ends[1:, 0]-pulse_start_ends[0:-1, 1] < 0.)):
 
         raise ArgumentsValueError('Pulse timing could not be properly deduced from '
@@ -284,7 +273,8 @@ def convert_dds_to_driven_control(
                                    'maximum_detuning_rate': maximum_detuning_rate,
                                    'minimum_segment_duration': minimum_segment_duration},
                                   extras={'deduced_pulse_start_timing': pulse_start_ends[:, 0],
-                                          'deduced_pulse_end_timing': pulse_start_ends[:, 1]})
+                                          'deduced_pulse_end_timing': pulse_start_ends[:, 1],
+                                          'gap_durations': gap_durations})
 
 
     if np.allclose(pulse_start_ends, 0.0):

--- a/qctrlopencontrols/dynamic_decoupling_sequences/driven_controls.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/driven_controls.py
@@ -79,7 +79,7 @@ def _check_maximum_rotation_rate(
     # check against global parameters
     if maximum_rabi_rate <= 0. or maximum_rabi_rate > UPPER_BOUND_RABI_RATE:
         raise ArgumentsValueError(
-            'Maximum rabi rate must be greater than 0. and less or equal to {0}'.format(
+            'Maximum rabi rate must be greater than 0 and less or equal to {0}'.format(
                 UPPER_BOUND_RABI_RATE),
             {'maximum_rabi_rate': maximum_rabi_rate},
             extras={'maximum_detuning_rate': maximum_detuning_rate,
@@ -87,11 +87,10 @@ def _check_maximum_rotation_rate(
 
     if maximum_detuning_rate <= 0. or maximum_detuning_rate > UPPER_BOUND_DETUNING_RATE:
         raise ArgumentsValueError(
-            'Maximum detuning rate must be greater than 0. and less or equalt o {0}'.format(
+            'Maximum detuning rate must be greater than 0 and less or equal to {0}'.format(
                 UPPER_BOUND_DETUNING_RATE),
             {'maximum_detuning_rate': maximum_detuning_rate, },
             extras={'maximum_rabi_rate': maximum_rabi_rate,
-                    'allowed_maximum_rabi_rate': UPPER_BOUND_RABI_RATE,
                     'allowed_maximum_detuning_rate': UPPER_BOUND_DETUNING_RATE})
 
 
@@ -112,9 +111,11 @@ def convert_dds_to_driven_control(
     dynamic_decoupling_sequence : qctrlopencontrols.DynamicDecouplingSequence
         The base DDS
     maximum_rabi_rate : float, optional
-        Maximum Rabi Rate. Defaults to 2*pi, and must be greater than 0 if set.
+        Maximum Rabi Rate; Defaults to 2*pi.
+        Must be greater than 0 and less or equal to UPPER_BOUND_RABI_RATE, if set.
     maximum_detuning_rate : float, optional
-        Maximum Detuning Rate; Defaults to 2*pi, and must be greater than 0 if set.
+        Maximum Detuning Rate; Defaults to 2*pi.
+        Must be greater than 0 and less or equal to UPPER_BOUND_DETUNING_RATE, if set.
     minimum_segment_duration : float, optional
         If set, further restricts the duration of every segment of the Driven Controls.
         Defaults to 0, in which case it does not affect the duration of the pulses.

--- a/qctrlopencontrols/dynamic_decoupling_sequences/driven_controls.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/driven_controls.py
@@ -109,7 +109,7 @@ def convert_dds_to_driven_control(
     Parameters
     ----------
     dynamic_decoupling_sequence : qctrlopencontrols.DynamicDecouplingSequence
-        The base DDS. Its offsets should be ordered in ascending order in time.
+        The base DDS. Its offsets should be sorted in ascending order in time.
     maximum_rabi_rate : float, optional
         Maximum Rabi Rate; Defaults to 2*pi.
         Must be greater than 0 and less or equal to UPPER_BOUND_RABI_RATE, if set.
@@ -235,7 +235,7 @@ def convert_dds_to_driven_control(
         half_pulse_duration  = 0.
 
         if not np.isclose(operations[1, op_idx], 0.): # Rabi rotation
-            half_pulse_duration = 0.5 * max(np.abs(operations[1, op_idx]) / maximum_rabi_rate,
+            half_pulse_duration = 0.5 * max(operations[1, op_idx] / maximum_rabi_rate,
                                             minimum_segment_duration)
         elif not np.isclose(operations[3, op_idx], 0.): # Detuning rotation
             half_pulse_duration = 0.5 * max(np.abs(operations[3, op_idx]) / maximum_detuning_rate,
@@ -258,8 +258,8 @@ def convert_dds_to_driven_control(
     gap_durations = pulse_start_ends[1:, 0] - pulse_start_ends[:-1, 1]
     if not np.all(np.logical_or(np.greater(gap_durations, 0.),
                                 np.isclose(gap_durations, 0.))):
-            raise ArgumentsValueError('There is overlap between pulses in the sequecence. '
-                                      'Try increasing the maximum rabi rate or maximum detuning rate.',
+            raise ArgumentsValueError("There is overlap between pulses in the sequence. "
+                                      "Try increasing the maximum rabi rate or maximum detuning rate.",
                                       {'dynamic_decoupling_sequence': dynamic_decoupling_sequence,
                                        'maximum_rabi_rate': maximum_rabi_rate,
                                        'maximum_detuning_rate': maximum_detuning_rate},

--- a/qctrlopencontrols/dynamic_decoupling_sequences/driven_controls.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/driven_controls.py
@@ -263,8 +263,8 @@ def convert_dds_to_driven_control(
     if not np.all(np.logical_or(np.greater(gap_durations, minimum_segment_duration),
                                 np.isclose(gap_durations, minimum_segment_duration))):
         raise ArgumentsValueError("Distance between pulses does not respect minimum_segment_duration. "
-                                  "Try decreasing the minimum_segment_duration or incresing "
-                                  "the maximum_rabi_rate or maximum_detuning_rate",
+                                  "Try decreasing the minimum_segment_duration or increasing "
+                                  "the maximum_rabi_rate or the maximum_detuning_rate.",
                                   {'dynamic_decoupling_sequence': dynamic_decoupling_sequence,
                                    'maximum_rabi_rate': maximum_rabi_rate,
                                    'maximum_detuning_rate': maximum_detuning_rate,

--- a/tests/test_dynamical_decoupling.py
+++ b/tests/test_dynamical_decoupling.py
@@ -581,23 +581,13 @@ def test_conversion_of_tightly_packed_sequence():
     a sequence tightly packed with pulses, where there is no time for a gap between
     the pi/2-pulses and the adjacent pi-pulses.
     """
-    # create a sequence containing 30 pi-pulses and 2 pi/2-pulses at the extremities
+    # create a sequence containing 2 pi-pulses and 2 pi/2-pulses at the extremities
     dynamic_decoupling_sequence = DynamicDecouplingSequence(
-        duration=3.0,
-        offsets=np.array([0., 0.05, 0.15, 0.25, 0.35, 0.45, 0.55, 0.65, 0.75, 0.85, 0.95,
-                          1.05, 1.15, 1.25, 1.35, 1.45, 1.55, 1.65, 1.75, 1.85, 1.95, 2.05,
-                          2.15, 2.25, 2.35, 2.45, 2.55, 2.65, 2.75, 2.85, 2.95, 3.]),
-        rabi_rotations=np.array([1.57079633, 3.14159265, 3.14159265, 3.14159265, 3.14159265,
-                                 3.14159265, 3.14159265, 3.14159265, 3.14159265, 3.14159265,
-                                 3.14159265, 3.14159265, 3.14159265, 3.14159265, 3.14159265,
-                                 3.14159265, 3.14159265, 3.14159265, 3.14159265, 3.14159265,
-                                 3.14159265, 3.14159265, 3.14159265, 3.14159265, 3.14159265,
-                                 3.14159265, 3.14159265, 3.14159265, 3.14159265, 3.14159265,
-                                 3.14159265, 1.57079633]),
-        azimuthal_angles=np.array([0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
-                                   0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.]),
-        detuning_rotations=np.array([0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
-                                     0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.]),
+        duration=0.2,
+        offsets=np.array([0., 0.05, 0.15, 0.2]),
+        rabi_rotations=np.array([1.57079633, 3.14159265, 3.14159265, 1.57079633]),
+        azimuthal_angles=np.array([0., 0., 0., 0.]),
+        detuning_rotations=np.array([0., 0., 0., 0.]),
         name=None)
 
     driven_control = convert_dds_to_driven_control(dynamic_decoupling_sequence,
@@ -606,11 +596,11 @@ def test_conversion_of_tightly_packed_sequence():
                                                    name=None)
 
     # There is no space for a gap between the pi/2-pulses and the adjacent pi-pulses,
-    # so the resulting sequence should have 32 pulses + 29 gaps = 61 segments with non-zero duration
-    assert sum(np.greater(driven_control.durations, 0.)) == 61
+    # so the resulting sequence should have 4 pulses + 1 gaps = 5 segments with non-zero duration
+    assert sum(np.greater(driven_control.durations, 0.)) == 5
 
-    # ... of which 32 are X pulses (i.e. rabi_rotation > 0)
-    assert sum(np.greater(driven_control.rabi_rates, 0.)) == 32
+    # ... of which 4 are X pulses (i.e. rabi_rotation > 0)
+    assert sum(np.greater(driven_control.rabi_rates, 0.)) == 4
 
 def test_free_evolution_conversion():
 

--- a/tests/test_dynamical_decoupling.py
+++ b/tests/test_dynamical_decoupling.py
@@ -575,6 +575,41 @@ def test_conversion_of_pulses_with_arbitrary_detuning_rotations():
     assert _all_greater_or_close(driven_control.duration, minimum_segment_duration)
 
 
+def test_conversion_of_tightly_packed_sequence():
+    """
+    Tests if the method to convert a DDS to driven controls handles properly
+    a sequence tightly packed with pulses.
+    """
+    # create a sequence containing 30 pi-pulses and 2 pi/2-pulses at the extremities
+    dynamic_decoupling_sequence = DynamicDecouplingSequence(
+        duration=3.0,
+        offsets=np.array([0., 0.05, 0.15, 0.25, 0.35, 0.45, 0.55, 0.65, 0.75, 0.85, 0.95,
+                          1.05, 1.15, 1.25, 1.35, 1.45, 1.55, 1.65, 1.75, 1.85, 1.95, 2.05,
+                          2.15, 2.25, 2.35, 2.45, 2.55, 2.65, 2.75, 2.85, 2.95, 3.]),
+        rabi_rotations=np.array([1.57079633, 3.14159265, 3.14159265, 3.14159265, 3.14159265,
+                                 3.14159265, 3.14159265, 3.14159265, 3.14159265, 3.14159265,
+                                 3.14159265, 3.14159265, 3.14159265, 3.14159265, 3.14159265,
+                                 3.14159265, 3.14159265, 3.14159265, 3.14159265, 3.14159265,
+                                 3.14159265, 3.14159265, 3.14159265, 3.14159265, 3.14159265,
+                                 3.14159265, 3.14159265, 3.14159265, 3.14159265, 3.14159265,
+                                 3.14159265, 1.57079633]),
+        azimuthal_angles=np.array([0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
+                                   0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.]),
+        detuning_rotations=np.array([0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
+                                     0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.]),
+        name=None)
+
+    driven_control = convert_dds_to_driven_control(dynamic_decoupling_sequence,
+                                                   maximum_rabi_rate= 20. * np.pi,
+                                                   minimum_segment_duration=0.,
+                                                   name=None)
+
+    # There is no space for a gap between the pi/2-pulses and the adjacent pi-pulses,
+    # so the resulting sequence should have 32 pulses + 29 gaps = 61 segments
+    assert len(driven_control.durations) == 61
+
+    # ... of which 32 are X pulses (i.e. rabi_rotation > 0)
+    assert sum(np.greater(driven_control.rabi_rates, 0.)) == 32
 
 def test_free_evolution_conversion():
 

--- a/tests/test_dynamical_decoupling.py
+++ b/tests/test_dynamical_decoupling.py
@@ -578,7 +578,8 @@ def test_conversion_of_pulses_with_arbitrary_detuning_rotations():
 def test_conversion_of_tightly_packed_sequence():
     """
     Tests if the method to convert a DDS to driven controls handles properly
-    a sequence tightly packed with pulses.
+    a sequence tightly packed with pulses, where there is no time for a gap between
+    the pi/2-pulses and the adjacent pi-pulses.
     """
     # create a sequence containing 30 pi-pulses and 2 pi/2-pulses at the extremities
     dynamic_decoupling_sequence = DynamicDecouplingSequence(
@@ -606,7 +607,7 @@ def test_conversion_of_tightly_packed_sequence():
 
     # There is no space for a gap between the pi/2-pulses and the adjacent pi-pulses,
     # so the resulting sequence should have 32 pulses + 29 gaps = 61 segments with non-zero duration
-    assert len(np.greater(driven_control.durations, 0.)) == 61
+    assert sum(np.greater(driven_control.durations, 0.)) == 61
 
     # ... of which 32 are X pulses (i.e. rabi_rotation > 0)
     assert sum(np.greater(driven_control.rabi_rates, 0.)) == 32


### PR DESCRIPTION
Final part of the fix for the bug found by Luigi. First part was PR #68

I split the checks of the timing of the pulses into two parts:
1. Checking that all the offsets are in ascending order in time (and adding the information about this requirement to the docstring).
2. Checking that none of the pulses overlap.

These two checks should be tolerant of floating point imprecisions now.

I added a unit test that replicates exactly the situation that Luigi reported. In the master branch, this test fails with the exception:

```
ArgumentsValueError: Pulse timing could not be properly deduced from the sequence operation offsets. Try increasing the maximum rabi rate or maximum detuning rate.
```