### PR TITLE
Fixing bug in DrivenControl.directions method

### DIFF
--- a/qctrlopencontrols/driven_controls/driven_control.py
+++ b/qctrlopencontrols/driven_controls/driven_control.py
@@ -280,7 +280,7 @@ class DrivenControl:
         )
 
         # Reduces tolerance of the comparison to zero in case the units chosen
-        # make the amplitudes very small, but never allows it be higher than the
+        # make the amplitudes very small, but never allows it to be higher than the
         # default atol value of 1e-8
         tolerance = min(1e-20 * np.max(amplitudes), 1e-8)
 

--- a/qctrlopencontrols/driven_controls/driven_control.py
+++ b/qctrlopencontrols/driven_controls/driven_control.py
@@ -278,23 +278,19 @@ class DrivenControl:
         amplitudes = np.sqrt(
             self.amplitude_x ** 2 + self.amplitude_y ** 2 + self.detunings ** 2
         )
+
+        amplitudes = np.where(np.isclose(amplitudes, 0.0), 1.0, amplitudes)
+
         normalized_amplitude_x = self.amplitude_x / amplitudes
         normalized_amplitude_y = self.amplitude_y / amplitudes
         normalized_detunings = self.detunings / amplitudes
 
-        normalized_amplitudes = np.hstack(
+        directions = np.hstack(
             (
                 normalized_amplitude_x[:, np.newaxis],
                 normalized_amplitude_y[:, np.newaxis],
                 normalized_detunings[:, np.newaxis],
             )
-        )
-
-        directions = np.array(
-            [
-                normalized_amplitudes if amplitudes[i] != 0.0 else np.zeros([3,])
-                for i in range(self.number_of_segments)
-            ]
         )
 
         return directions

--- a/qctrlopencontrols/driven_controls/driven_control.py
+++ b/qctrlopencontrols/driven_controls/driven_control.py
@@ -279,11 +279,18 @@ class DrivenControl:
             self.amplitude_x ** 2 + self.amplitude_y ** 2 + self.detunings ** 2
         )
 
-        amplitudes = np.where(np.isclose(amplitudes, 0.0), 1.0, amplitudes)
+        # Reduces tolerance of the comparison to zero in case the units chosen
+        # make the amplitudes very small, but never allows it be higher than the
+        # default atol value of 1e-8
+        tolerance = min(1e-20 * np.max(amplitudes), 1e-8)
 
-        normalized_amplitude_x = self.amplitude_x / amplitudes
-        normalized_amplitude_y = self.amplitude_y / amplitudes
-        normalized_detunings = self.detunings / amplitudes
+        safe_amplitudes = np.where(
+            np.isclose(amplitudes, 0, atol=tolerance), 1.0, amplitudes
+        )
+
+        normalized_amplitude_x = self.amplitude_x / safe_amplitudes
+        normalized_amplitude_y = self.amplitude_y / safe_amplitudes
+        normalized_detunings = self.detunings / safe_amplitudes
 
         directions = np.hstack(
             (

--- a/tests/test_driven_controls.py
+++ b/tests/test_driven_controls.py
@@ -163,6 +163,28 @@ def test_control_directions():
     assert np.allclose(driven_control.directions, expected_directions)
 
 
+def test_control_directions_with_small_amplitudes():
+    """Tests if the directions method works with very small amplitudes."""
+    rabi_rates = [1e-100, 0.0, 1e-100, 0.0]
+    azimuthal_angles = [0, 0, np.pi / 2, 0]
+    detunings = [0, 0, 0, 1e-100]
+    durations = [1, 1, 1, 1]
+
+    name = "driven_control"
+
+    expected_directions = [[1, 0, 0], [0, 0, 0], [0, 1, 0], [0, 0, 1]]
+
+    driven_control = DrivenControl(
+        rabi_rates=rabi_rates,
+        azimuthal_angles=azimuthal_angles,
+        detunings=detunings,
+        durations=durations,
+        name=name,
+    )
+
+    assert np.allclose(driven_control.directions, expected_directions)
+
+
 def test_control_export():
 
     """Tests exporting the control to a file

--- a/tests/test_driven_controls.py
+++ b/tests/test_driven_controls.py
@@ -141,6 +141,28 @@ def test_driven_controls():
         )
 
 
+def test_control_directions():
+    """Tests if the directions method works properly."""
+    rabi_rates = [1, 0, 1, 0]
+    azimuthal_angles = [0, 0, np.pi / 2, 0]
+    detunings = [0, 0, 0, 1]
+    durations = [1, 1, 1, 1]
+
+    name = "driven_control"
+
+    expected_directions = [[1, 0, 0], [0, 0, 0], [0, 1, 0], [0, 0, 1]]
+
+    driven_control = DrivenControl(
+        rabi_rates=rabi_rates,
+        azimuthal_angles=azimuthal_angles,
+        detunings=detunings,
+        durations=durations,
+        name=name,
+    )
+
+    assert np.allclose(driven_control.directions, expected_directions)
+
+
 def test_control_export():
 
     """Tests exporting the control to a file


### PR DESCRIPTION
Currently, running

```
from qctrlopencontrols import DrivenControl
control = DrivenControl(rabi_rates=[1, 0, 1], detunings=[0, 0, 0], durations=[1, 1, 1])
control.directions
```

will result in an error, because the segment with zero amplitude (the second segment) will cause a division by zero in the `directions` method. This patch prevents that division by zero.

Let me know if you'd prefer a different solution