### PR TITLE
Remove unused file

### DIFF
--- a/matplotlibrc
+++ b/matplotlibrc
@@ -1,1 +1,0 @@
-backend: agg


### PR DESCRIPTION
It seems `matplotlibrc` is used for customized style in the plot
https://matplotlib.org/3.2.2/tutorials/introductory/customizing.html,
but not really been used in the repo.