### PR TITLE
Fix pre-post rotations

### DIFF
--- a/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
@@ -42,7 +42,7 @@ def _add_pre_post_rotations(
     """Adds a pre and post X rotation at the start and end of the sequence.
 
     Note that with these two pre and post X rotations, the net effect of the DDS does not
-    necessarily have to be an identity. For example, given a CPMG sequences of odd number Y pi
+    necessarily have to be an identity. For example, given a CPMG sequence of odd number Y pi
     rotations in the middle with the pre (pi/2) and post(-pi/2) X rotations, the net effect will
     be a Z gate.
 

--- a/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
@@ -127,9 +127,10 @@ def _add_pre_post_rotations(
     # of Y and Z pi-pulses
     preserves_11 = (y_pi_pulses + z_pi_pulses) % 2 == 0
 
-    # use pi/2 and -pi/2 (pi/2) X pulses as pre and post rotations for CP sequences with
-    # odd(even) number of pulses
-    # always use pi/2 and -pi/2 X pulses as pre and post rotations for CPMG sequences
+    # the direction of final rotation depends on the property of DDS.
+    # if the net effect of the sequences is an identity gate or Y rotation, the post rotation
+    # is chosen to be -pi/2 X pulse, otherwise use pi/2 X pulse, to ensure the final gate is an
+    # identity or Z rotation.
     if (preserves_10 and preserves_11) or (not preserves_10 and not preserves_11):
         final_azimuthal = np.pi
 

--- a/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
@@ -127,9 +127,9 @@ def _add_pre_post_rotations(
     # of Y and Z pi-pulses
     preserves_11 = (y_pi_pulses + z_pi_pulses) % 2 == 0
 
-    # the direction of final rotation depends on the property of DDS.
+    # the direction of the post rotation depends on the property of DDS.
     # if the net effect of the sequences is an identity gate or Y rotation, the post rotation
-    # is chosen to be -pi/2 X pulse, otherwise use pi/2 X pulse, to ensure the final gate is an
+    # is chosen to be -pi/2 X pulse, otherwise use pi/2 X pulse, to ensure the net effect is an
     # identity or Z rotation.
     if (preserves_10 and preserves_11) or (not preserves_10 and not preserves_11):
         final_azimuthal = np.pi

--- a/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
@@ -39,12 +39,12 @@ from .dynamic_decoupling_sequence import DynamicDecouplingSequence
 def _add_pre_post_rotations(
     duration, offsets, rabi_rotations, azimuthal_angles, detuning_rotations
 ):
-    """Adds a pre(pi/2 X pulse) and post(-pi/2 X pulse) rotation at the start and end of the
-    sequence.
+    """Adds a pre and post X rotation at the start and end of the sequence.
 
     Note that with these two pre and post X rotations, the net effect of the DDS does not
-    necessarily have to be an identity. For example, given a CPMG sequences with Y pi rotations
-    in the middle and two pre-post X pi/2 rotations, the net effect will be a Z gate.
+    necessarily have to be an identity. For example, given a CPMG sequences of odd number Y pi
+    rotations in the middle with the pre (pi/2) and post(-pi/2) X rotations, the net effect will
+    be a Z gate.
 
     This function assumes that the sequences only have X, Y, and Z pi-pulses.
     An exception is thrown if that is not the case.

--- a/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
@@ -42,9 +42,9 @@ def _add_pre_post_rotations(
     """Adds a pre and post X rotation at the start and end of the sequence.
 
     Note that with these two pre and post X rotations, the net effect of the DDS does not
-    necessarily have to be an identity. For example, given a CPMG sequence of odd number Y pi
-    rotations in the middle with the pre (pi/2) and post(-pi/2) X rotations, the net effect will
-    be a Z gate.
+    necessarily have to be an identity, but it will always be either an identity or Z pi rotation.
+    For example, given a CPMG sequence of odd number Y pi rotations in the middle with the pre
+    (pi/2) and post(-pi/2) X rotations, the net effect will be a Z gate.
 
     This function assumes that the sequences only have X, Y, and Z pi-pulses.
     An exception is thrown if that is not the case.
@@ -130,7 +130,7 @@ def _add_pre_post_rotations(
     # use pi/2 and -pi/2 (pi/2) X pulses as pre and post rotations for CP sequences with
     # odd(even) number of pulses
     # always use pi/2 and -pi/2 X pulses as pre and post rotations for CPMG sequences
-    if preserves_10 or (not preserves_11):
+    if (preserves_10 and preserves_11) or (not preserves_10 and not preserves_11):
         final_azimuthal = np.pi
 
     offsets = np.insert(offsets, [0, offsets.shape[0]], [0, duration],)

--- a/tests/test_predefined_dynamical_decoupling.py
+++ b/tests/test_predefined_dynamical_decoupling.py
@@ -680,7 +680,7 @@ def _pulses_produce_identity(sequence, extra_rotation=None):
     We check this by creating the unitary of each pulse and then multiplying them
     by each other to check the complete evolution.
 
-    However, Note that DDS sequence does not necessarily has to produce an identity gate.
+    However, note that DDS sequence does not necessarily has to produce an identity gate.
     For example, the net effect of CPMG sequences with odd number of pulses is a Z rotation.
     ``extra_rotation`` is used to compensate this net effect.
     """
@@ -770,7 +770,7 @@ def test_if_carr_purcell_sequence_with_even_pulses_is_identity():
 def test_if_cpmg_sequence_with_odd_pulses_is_identity():
     """
     Tests if the product of the pulses in a CPMG sequence with pre/post
-    pi/2-pulses with an extra Z rotation is an identity, when the number of pulses is odd.
+    pi/2-pulses and an extra Z rotation is an identity, when the number of pulses is odd.
     """
     odd_cpmg_sequence = new_predefined_dds(
         scheme=CARR_PURCELL_MEIBOOM_GILL,
@@ -932,7 +932,8 @@ def test_if_quadratic_sequence_with_even_pulses_is_identity():
 def test_if_quadratic_sequence_with_odd_inner_pulses_is_identity():
     """
     Tests if the product of the pulses in a quadratic sequence with pre/post
-    pi/2-pulses with an extra rotation is an identity, when the total number of inner pulses is odd.
+    pi/2-pulses and an extra rotation is an identity, when the total number
+    of inner pulses is odd.
     """
     inner_odd_quadratic_sequence = new_predefined_dds(
         scheme=QUADRATIC,

--- a/tests/test_predefined_dynamical_decoupling.py
+++ b/tests/test_predefined_dynamical_decoupling.py
@@ -36,6 +36,10 @@ from qctrlopencontrols.dynamic_decoupling_sequences import (
 )
 from qctrlopencontrols.exceptions import ArgumentsValueError
 
+SIGMA_X = np.array([[0.0, 1.0], [1.0, 0.0]])
+SIGMA_Y = np.array([[0.0, -1.0j], [1.0j, 0.0]])
+SIGMA_Z = np.array([[1.0, 0.0], [0.0, -1.0]])
+
 
 def test_ramsey():
 
@@ -670,18 +674,19 @@ def test_attribute_values():
         )
 
 
-def _pulses_produce_identity(sequence):
+def _pulses_produce_identity(sequence, extra_rotation=None):
     """
     Tests if the pulses of a DDS sequence produce an identity in absence of noise.
     We check this by creating the unitary of each pulse and then multiplying them
     by each other to check the complete evolution.
+
+    However, Note that DDS sequence does not necessarily has to produce an identity gate.
+    For example, the net effect of CPMG sequences with odd number of pulses is a Z rotation.
+    ``extra_rotation`` is used to compensate this net effect.
     """
-    sigma_x = np.array([[0.0, 1.0], [1.0, 0.0]])
-    sigma_y = np.array([[0.0, -1.0j], [1.0j, 0.0]])
-    sigma_z = np.array([[1.0, 0.0], [0.0, -1.0]])
 
     # The unitary evolution due to an instantaneous pulse can be written as
-    # U = cos(|n|) I -i sin(|n|) *(n_x sigma_x + n_y sigma_y + n_z sigma_z)/|n|
+    # U = cos(|n|) I -i sin(|n|) *(n_x SIGMA_x + n_y SIGMA_y + n_z SIGMA_z)/|n|
     # where n is a vector with components
     # n_x = rabi * cos(azimuthal)/2
     # n_y = rabi * sin(azimuthal)/2
@@ -697,14 +702,17 @@ def _pulses_produce_identity(sequence):
         mod_n = np.sqrt(n_x ** 2 + n_y ** 2 + n_z ** 2)
         unitary = (
             np.cos(mod_n) * np.identity(2)
-            - 1.0j * (np.sin(mod_n) * n_x / mod_n) * sigma_x
-            - 1.0j * (np.sin(mod_n) * n_y / mod_n) * sigma_y
-            - 1.0j * (np.sin(mod_n) * n_z / mod_n) * sigma_z
+            - 1.0j * (np.sin(mod_n) * n_x / mod_n) * SIGMA_X
+            - 1.0j * (np.sin(mod_n) * n_y / mod_n) * SIGMA_Y
+            - 1.0j * (np.sin(mod_n) * n_z / mod_n) * SIGMA_Z
         )
         matrix_product = np.matmul(unitary, matrix_product)
 
     # Remove global phase
     matrix_product *= np.exp(-1.0j * np.angle(matrix_product[0][0]))
+
+    if extra_rotation is not None:
+        matrix_product = matrix_product.dot(extra_rotation)
 
     expected_matrix_product = np.identity(2)
 
@@ -762,7 +770,7 @@ def test_if_carr_purcell_sequence_with_even_pulses_is_identity():
 def test_if_cpmg_sequence_with_odd_pulses_is_identity():
     """
     Tests if the product of the pulses in a CPMG sequence with pre/post
-    pi/2-pulses is an identity, when the number of pulses is odd.
+    pi/2-pulses with an extra Z rotation is an identity, when the number of pulses is odd.
     """
     odd_cpmg_sequence = new_predefined_dds(
         scheme=CARR_PURCELL_MEIBOOM_GILL,
@@ -771,7 +779,7 @@ def test_if_cpmg_sequence_with_odd_pulses_is_identity():
         pre_post_rotation=True,
     )
 
-    assert _pulses_produce_identity(odd_cpmg_sequence)
+    assert _pulses_produce_identity(odd_cpmg_sequence, extra_rotation=SIGMA_Z)
 
 
 def test_if_cpmg_sequence_with_even_pulses_is_identity():
@@ -792,7 +800,7 @@ def test_if_cpmg_sequence_with_even_pulses_is_identity():
 def test_if_uhrig_sequence_with_odd_pulses_is_identity():
     """
     Tests if the product of the pulses in an Uhrig sequence with pre/post
-    pi/2-pulses is an identity, when the number of pulses is odd.
+    pi/2-pulses and an extra Z rotation is an identity, when the number of pulses is odd.
     """
     odd_uhrig_sequence = new_predefined_dds(
         scheme=UHRIG_SINGLE_AXIS,
@@ -801,7 +809,7 @@ def test_if_uhrig_sequence_with_odd_pulses_is_identity():
         pre_post_rotation=True,
     )
 
-    assert _pulses_produce_identity(odd_uhrig_sequence)
+    assert _pulses_produce_identity(odd_uhrig_sequence, extra_rotation=SIGMA_Z)
 
 
 def test_if_uhrig_sequence_with_even_pulses_is_identity():
@@ -924,7 +932,7 @@ def test_if_quadratic_sequence_with_even_pulses_is_identity():
 def test_if_quadratic_sequence_with_odd_inner_pulses_is_identity():
     """
     Tests if the product of the pulses in a quadratic sequence with pre/post
-    pi/2-pulses is an identity, when the total number of inner pulses is odd.
+    pi/2-pulses with an extra rotation is an identity, when the total number of inner pulses is odd.
     """
     inner_odd_quadratic_sequence = new_predefined_dds(
         scheme=QUADRATIC,
@@ -938,7 +946,9 @@ def test_if_quadratic_sequence_with_odd_inner_pulses_is_identity():
     # total number here is odd
     assert len(inner_odd_quadratic_sequence.offsets) == 8 + 7 * (8 + 1) + 2
 
-    assert _pulses_produce_identity(inner_odd_quadratic_sequence)
+    assert _pulses_produce_identity(
+        inner_odd_quadratic_sequence, extra_rotation=SIGMA_X.dot(-SIGMA_Z)
+    )
 
 
 def test_if_quadratic_sequence_with_even_inner_pulses_is_identity():

--- a/tests/test_predefined_dynamical_decoupling.py
+++ b/tests/test_predefined_dynamical_decoupling.py
@@ -680,7 +680,7 @@ def _pulses_produce_identity(sequence, extra_rotation=None):
     We check this by creating the unitary of each pulse and then multiplying them
     by each other to check the complete evolution.
 
-    However, note that DDS sequence does not necessarily have to produce an identity gate.
+    Note that the net effect of DDS sequence is either an identity gate or a Z pi rotation.
     For example, CPMG sequence with odd number of Y pulses produces a Z rotation.
     ``extra_rotation`` is used to compensate this net effect.
     """
@@ -948,7 +948,7 @@ def test_if_quadratic_sequence_with_odd_inner_pulses_is_identity():
     assert len(inner_odd_quadratic_sequence.offsets) == 8 + 7 * (8 + 1) + 2
 
     assert _pulses_produce_identity(
-        inner_odd_quadratic_sequence, extra_rotation=np.matmul(SIGMA_X, -SIGMA_Z)
+        inner_odd_quadratic_sequence, extra_rotation=SIGMA_Z
     )
 
 

--- a/tests/test_predefined_dynamical_decoupling.py
+++ b/tests/test_predefined_dynamical_decoupling.py
@@ -712,7 +712,7 @@ def _pulses_produce_identity(sequence, extra_rotation=None):
     matrix_product *= np.exp(-1.0j * np.angle(matrix_product[0][0]))
 
     if extra_rotation is not None:
-        matrix_product = matrix_product.dot(extra_rotation)
+        matrix_product = np.matmul(matrix_product, extra_rotation)
 
     expected_matrix_product = np.identity(2)
 

--- a/tests/test_predefined_dynamical_decoupling.py
+++ b/tests/test_predefined_dynamical_decoupling.py
@@ -680,8 +680,8 @@ def _pulses_produce_identity(sequence, extra_rotation=None):
     We check this by creating the unitary of each pulse and then multiplying them
     by each other to check the complete evolution.
 
-    However, note that DDS sequence does not necessarily has to produce an identity gate.
-    For example, the net effect of CPMG sequences with odd number of pulses is a Z rotation.
+    However, note that DDS sequence does not necessarily have to produce an identity gate.
+    For example, CPMG sequence with odd number of Y pulses produces a Z rotation.
     ``extra_rotation`` is used to compensate this net effect.
     """
 

--- a/tests/test_predefined_dynamical_decoupling.py
+++ b/tests/test_predefined_dynamical_decoupling.py
@@ -948,7 +948,7 @@ def test_if_quadratic_sequence_with_odd_inner_pulses_is_identity():
     assert len(inner_odd_quadratic_sequence.offsets) == 8 + 7 * (8 + 1) + 2
 
     assert _pulses_produce_identity(
-        inner_odd_quadratic_sequence, extra_rotation=SIGMA_X.dot(-SIGMA_Z)
+        inner_odd_quadratic_sequence, extra_rotation=np.matmul(SIGMA_X, -SIGMA_Z)
     )
 
 


### PR DESCRIPTION
As discussed in https://q-ctrl.atlassian.net/browse/QENG-974
we now add x rotations unconditionally to all DDS, but the sign of the post-rotation could be different depending on the control scheme. The net effect of DDS now does not have to be identity, this is captured in tests.

I have a strange test error. All tests pass on local machines (tested on Mac and Linux). However, there seem random failures in CI. The issue is related to the function `test_if_quadratic_sequence_with_odd_inner_pulses_is_identity` in ` tests/test_predefined_dynamical_decoupling.py`. See commit `75e3a6c` for example. I notice sometimes rerun the action would resolve the issue, but I don't have a clue why it happens. @leoadec @charmasaur 
