### PR TITLE
Add a function to check arguments

### DIFF
--- a/qctrlopencontrols/utils.py
+++ b/qctrlopencontrols/utils.py
@@ -87,13 +87,25 @@ def check_arguments(condition, description, arguments, extras=None):
     Raises an ArgumentsValueError with the specified parameters if the given condition is false,
     otherwise does nothing.
 
+    For example,  a use case may look like::
+
+        def log(x):
+            check_arguments(x > 0,
+                            "x must be positive.",
+                            {"x": x})
+            return numpy.log(x)
+
     Parameters
     ----------
-    conditions: Any
+    condition: Any
+        The condition to be checked. Evaluated result of the condition must be bool.
     description: str
+        Error information to explain why condition fails.
     arguments: dict
-    extra: dict, optional
-
+        arguments that fail the condition. Key should be the name of the arguments and arguments are
+        the values.
+    extras: dict, optional
+        Any extra information to explain why condition fails.
     Raises
     ------
     ArgumentsValueError

--- a/qctrlopencontrols/utils.py
+++ b/qctrlopencontrols/utils.py
@@ -87,7 +87,7 @@ def check_arguments(condition, description, arguments, extras=None):
     Raises an ArgumentsValueError with the specified parameters if the given condition is false,
     otherwise does nothing.
 
-    For example,  a use case may look like::
+    For example, a use case may look like::
 
         def log(x):
             check_arguments(x > 0,
@@ -102,10 +102,10 @@ def check_arguments(condition, description, arguments, extras=None):
     description: str
         Error information to explain why condition fails.
     arguments: dict
-        arguments that fail the condition. Key should be the name of the arguments and arguments are
-        the values.
+        arguments that fail the condition. Keys should be the names of the arguments and arguments
+        are the values.
     extras: dict, optional
-        Any extra information to explain why condition fails.
+        Any extra information to explain why condition fails. Defaults to None.
     Raises
     ------
     ArgumentsValueError

--- a/qctrlopencontrols/utils.py
+++ b/qctrlopencontrols/utils.py
@@ -82,6 +82,28 @@ def create_repr_from_attributes(class_instance=None, attributes=None):
     return repr_string
 
 
+def check_arguments(condition, description, arguments, extras=None):
+    """
+    Raises an ArgumentsValueError with the specified parameters if the given condition is false,
+    otherwise does nothing.
+
+    Parameters
+    -----------
+    conditions: Any
+    description: str
+    arguments: dict
+    extra: dict, optional
+
+    Raises
+    ------
+    ArgumentsValueError
+        If condition is false.
+    """
+    if condition:
+        return
+    raise ArgumentsValueError(description, arguments, extras=extras)
+
+
 class FileFormat(Enum):
     """
     Defines exported file format.

--- a/qctrlopencontrols/utils.py
+++ b/qctrlopencontrols/utils.py
@@ -88,7 +88,7 @@ def check_arguments(condition, description, arguments, extras=None):
     otherwise does nothing.
 
     Parameters
-    -----------
+    ----------
     conditions: Any
     description: str
     arguments: dict


### PR DESCRIPTION
While adding `mypy` to check type, it seems some refactor for argument checking is necessary besides just adding type hints. It will be easier to add this check function first.
 
We might apply this function for all arguments check in the future. 

This is also part of the issue https://github.com/qctrl/python-open-controls/issues/90#issue-653672409