### PR TITLE
Add type hint for drive control module

### DIFF
--- a/qctrlopencontrols/driven_controls/driven_control.py
+++ b/qctrlopencontrols/driven_controls/driven_control.py
@@ -113,10 +113,10 @@ class DrivenControl:
         if durations is None:
             durations = np.ones(input_length)
 
-        self.rabi_rates = np.array(rabi_rates)
-        self.azimuthal_angles = np.array(azimuthal_angles)
-        self.detunings = np.array(detunings)
-        self.durations = np.array(durations)
+        self.rabi_rates = np.array(rabi_rates, dtype=np.float)
+        self.azimuthal_angles = np.array(azimuthal_angles, dtype=np.float)
+        self.detunings = np.array(detunings, dtype=np.float)
+        self.durations = np.array(durations, dtype=np.float)
 
         # check if all the rabi_rates are greater than zero
         if np.any(self.rabi_rates < 0.0):

--- a/qctrlopencontrols/driven_controls/driven_control.py
+++ b/qctrlopencontrols/driven_controls/driven_control.py
@@ -46,16 +46,16 @@ class DrivenControl:
     ----------
     rabi_rates : numpy.ndarray, optional
         1-D array of size nx1 where n is number of segments;
-        Each entry is the rabi rate for the segment. Defaults to None
+        Each entry is the rabi rate for the segment. Defaults to None.
     azimuthal_angles : numpy.ndarray, optional
         1-D array of size nx1 where n is the number of segments;
-        Each entry is the azimuthal angle for the segment; Defaults to None
+        Each entry is the azimuthal angle for the segment; Defaults to None.
     detunings : numpy.ndarray, optional
         1-D array of size nx1 where n is the number of segments;
-        Each entry is the detuning angle for the segment; Defaults to None
+        Each entry is the detuning angle for the segment; Defaults to None.
     durations : numpy.ndarray, optional
         1-D array of size nx1 where n is the number of segments;
-        Each entry is the duration of the segment (in seconds); Defaults to None
+        Each entry is the duration of the segment (in seconds); Defaults to None.
     name : string, optional
         An optional string to name the driven control. Defaults to None.
 
@@ -85,7 +85,7 @@ class DrivenControl:
 
         # check if all non-None inputs have the same length
         input_lengths = {
-            len(v)
+            np.array(v).size
             for v in [rabi_rates, azimuthal_angles, detunings, durations]
             if v is not None
         }
@@ -113,10 +113,10 @@ class DrivenControl:
         if durations is None:
             durations = np.ones(input_length)
 
-        self.rabi_rates = np.array(rabi_rates, dtype=np.float)
-        self.azimuthal_angles = np.array(azimuthal_angles, dtype=np.float)
-        self.detunings = np.array(detunings, dtype=np.float)
-        self.durations = np.array(durations, dtype=np.float)
+        self.rabi_rates = np.array(rabi_rates, dtype=np.float).flatten()
+        self.azimuthal_angles = np.array(azimuthal_angles, dtype=np.float).flatten()
+        self.detunings = np.array(detunings, dtype=np.float).flatten()
+        self.durations = np.array(durations, dtype=np.float).flatten()
 
         # check if all the rabi_rates are greater than zero
         if np.any(self.rabi_rates < 0.0):

--- a/qctrlopencontrols/driven_controls/driven_control.py
+++ b/qctrlopencontrols/driven_controls/driven_control.py
@@ -76,15 +76,14 @@ class DrivenControl:
 
         self.name = name
 
-        if all(
-            v is not None for v in [rabi_rates, azimuthal_angles, detunings, durations]
-        ):
+        # set default values if all inputs are ``None``
+        if all(v is None for v in [rabi_rates, azimuthal_angles, detunings, durations]):
             rabi_rates = np.array([np.pi])
             azimuthal_angles = np.array([0.0])
             detunings = np.array([0.0])
             durations = np.array([1.0])
 
-        # check all non-non inputs have the same length
+        # check if all non-None inputs have the same length
         input_lengths = {
             len(v)
             for v in [rabi_rates, azimuthal_angles, detunings, durations]
@@ -114,13 +113,13 @@ class DrivenControl:
         if durations is None:
             durations = np.ones(input_length)
 
-        self.rabi_rates = rabi_rates
-        self.azimuthal_angles = azimuthal_angles
-        self.detunings = detunings
-        self.durations = durations
+        self.rabi_rates = np.array(rabi_rates)
+        self.azimuthal_angles = np.array(azimuthal_angles)
+        self.detunings = np.array(detunings)
+        self.durations = np.array(durations)
 
         # check if all the rabi_rates are greater than zero
-        if np.any(rabi_rates < 0.0):
+        if np.any(self.rabi_rates < 0.0):
             raise ArgumentsValueError(
                 "All rabi rates must be greater than zero.",
                 {"rabi_rates": rabi_rates},
@@ -132,7 +131,7 @@ class DrivenControl:
             )
 
         # check if all the durations are greater than zero
-        if np.any(durations <= 0):
+        if np.any(self.durations <= 0):
             raise ArgumentsValueError(
                 "Duration of driven control segments must all be greater"
                 + " than zero.",

--- a/tests/test_driven_controls.py
+++ b/tests/test_driven_controls.py
@@ -344,7 +344,7 @@ def test_pretty_print():
     _maximum_detuning = 1.0
     _rabi_rates = [0.0, 0.0, 0.0]
     _azimuthal_angles = [0, np.pi / 2, -np.pi / 2]
-    _detunings = [0, 1.0, 0]
+    _detunings = [0, 1, 0]
     _durations = [1.0, 1.0, 1.0]
 
     driven_control = DrivenControl(
@@ -385,7 +385,7 @@ def test_pretty_print():
     _maximum_detuning = 0.0
     _rabi_rates = [np.pi, 2 * np.pi, np.pi]
     _azimuthal_angles = [0, np.pi / 2, -np.pi / 2]
-    _detunings = [0.0, 0.0, 0.0]
+    _detunings = [0, 0, 0]
     _durations = [1.0, 1.0, 1.0]
 
     driven_control = DrivenControl(

--- a/tests/test_driven_controls.py
+++ b/tests/test_driven_controls.py
@@ -385,7 +385,7 @@ def test_pretty_print():
     _maximum_detuning = 0.0
     _rabi_rates = [np.pi, 2 * np.pi, np.pi]
     _azimuthal_angles = [0, np.pi / 2, -np.pi / 2]
-    _detunings = [0, 0, 0]
+    _detunings = [0, 0.0, 0]
     _durations = [1.0, 1.0, 1.0]
 
     driven_control = DrivenControl(

--- a/tests/test_driven_controls.py
+++ b/tests/test_driven_controls.py
@@ -335,7 +335,7 @@ def test_pretty_print():
     _maximum_detuning = 1.0
     _rabi_rates = [0.0, 0.0, 0.0]
     _azimuthal_angles = [0, np.pi / 2, -np.pi / 2]
-    _detunings = [0, 1, 0]
+    _detunings = [0, 1.0, 0]
     _durations = [1.0, 1.0, 1.0]
 
     driven_control = DrivenControl(
@@ -376,7 +376,7 @@ def test_pretty_print():
     _maximum_detuning = 0.0
     _rabi_rates = [np.pi, 2 * np.pi, np.pi]
     _azimuthal_angles = [0, np.pi / 2, -np.pi / 2]
-    _detunings = [0, 0.0, 0]
+    _detunings = [0.0, 0.0, 0.0]
     _durations = [1.0, 1.0, 1.0]
 
     driven_control = DrivenControl(


### PR DESCRIPTION
Add type hint

For passing `mypy` test, some refactoring is done for checking the inputs. The main purposes of these checking are:
1. set proper default values when inputs are all ``None``
2. make sure all non ``None`` inputs have the same shape
3. set the proper values for ``None`` input

Note that type hint is not added for those properties as I am planning to rearrange those checkings first. Will do in another PR.