### PR TITLE
Fix scheme names and make private function names consistent

### DIFF
--- a/qctrlopencontrols/driven_controls/predefined.py
+++ b/qctrlopencontrols/driven_controls/predefined.py
@@ -44,22 +44,22 @@ from .driven_control import DrivenControl
 
 def new_predefined_driven_control(scheme: str = PRIMITIVE, **kwargs):
     """
-    Create a new driven control
+    Creates a new driven control based on the given scheme.
 
     Parameters
     ----------
     scheme : string, optional
-        Defaults to None. The name of the driven control type,
+        Defaults to 'primitive'. The name of the driven control type,
         supported options are:
         - 'primitive'
-        - 'wimperis_1'
-        - 'solovay_kitaev_1'
-        - 'compensating_for_off_resonance_with_a_pulse_sequence'
-        - 'compensating_for_off_resonance_with_a_pulse_sequence_with_wimperis'
-        - 'compensating_for_off_resonance_with_a_pulse_sequence_with_solovay_kitaev'
-        - 'walsh_amplitude_modulated_filter_1'
-        - 'short_composite_rotation_for_undoing_length_over_and_under_shoot'
-        - 'corpse_in_scrofulous'
+        - 'BB1'
+        - 'SK1'
+        - 'CORPSE'
+        - 'CORPSE in BB1'
+        - 'CORPSE in SK1'
+        - 'WAMF1'
+        - 'SCROFULOUS'
+        - 'CORPSE in SCROFULOUS'
     kwargs : dict, optional
         options to make the corresponding control type.
 
@@ -78,27 +78,19 @@ def new_predefined_driven_control(scheme: str = PRIMITIVE, **kwargs):
     if scheme == PRIMITIVE:
         driven_control = _new_primitive_control(**kwargs)
     elif scheme == BB1:
-        driven_control = _new_wimperis_1_control(**kwargs)
+        driven_control = _new_bb1_control(**kwargs)
     elif scheme == SK1:
-        driven_control = _new_solovay_kitaev_1_control(**kwargs)
+        driven_control = _new_sk1_control(**kwargs)
     elif scheme == WAMF1:
-        driven_control = _new_walsh_amplitude_modulated_filter_1_control(**kwargs)
+        driven_control = _new_wamf1_control(**kwargs)
     elif scheme == CORPSE:
-        driven_control = _new_compensating_for_off_resonance_with_a_pulse_sequence_control(
-            **kwargs
-        )
+        driven_control = _new_corpse_control(**kwargs)
     elif scheme == CORPSE_IN_BB1:
-        driven_control = _new_compensating_for_off_resonance_with_a_sequence_with_wimperis_control(
-            **kwargs
-        )
+        driven_control = _new_corpse_in_bb1_control(**kwargs)
     elif scheme == CORPSE_IN_SK1:
-        driven_control = _new_compensating_for_off_resonance_with_a_sequence_with_sk_control(
-            **kwargs
-        )
+        driven_control = _new_corpse_in_sk1_control(**kwargs)
     elif scheme == SCROFULOUS:
-        driven_control = _short_composite_rotation_for_undoing_length_over_under_shoot_control(
-            **kwargs
-        )
+        driven_control = _new_scrofulous_control(**kwargs)
     elif scheme == CORPSE_IN_SCROFULOUS:
         driven_control = _new_corpse_in_scrofulous_control(**kwargs)
     else:
@@ -257,7 +249,7 @@ def _new_primitive_control(
     )
 
 
-def _new_wimperis_1_control(
+def _new_bb1_control(
     rabi_rotation: float,
     azimuthal_angle: float = 0.0,
     maximum_rabi_rate: float = 2.0 * np.pi,
@@ -312,7 +304,7 @@ def _new_wimperis_1_control(
     )
 
 
-def _new_solovay_kitaev_1_control(
+def _new_sk1_control(
     rabi_rotation: float,
     azimuthal_angle: float = 0.0,
     maximum_rabi_rate: float = 2.0 * np.pi,
@@ -366,7 +358,7 @@ def _new_solovay_kitaev_1_control(
     )
 
 
-def _short_composite_rotation_for_undoing_length_over_under_shoot_control(
+def _new_scrofulous_control(
     rabi_rotation: float,
     azimuthal_angle: float = 0.0,
     maximum_rabi_rate: float = 2.0 * np.pi,
@@ -457,7 +449,7 @@ def _short_composite_rotation_for_undoing_length_over_under_shoot_control(
     )
 
 
-def _new_compensating_for_off_resonance_with_a_pulse_sequence_control(
+def _new_corpse_control(
     rabi_rotation: float,
     azimuthal_angle: float = 0.0,
     maximum_rabi_rate: float = 2.0 * np.pi,
@@ -511,7 +503,7 @@ def _new_compensating_for_off_resonance_with_a_pulse_sequence_control(
     )
 
 
-def _new_compensating_for_off_resonance_with_a_sequence_with_wimperis_control(
+def _new_corpse_in_bb1_control(
     rabi_rotation: float,
     azimuthal_angle: float = 0.0,
     maximum_rabi_rate: float = 2.0 * np.pi,
@@ -579,7 +571,7 @@ def _new_compensating_for_off_resonance_with_a_sequence_with_wimperis_control(
     )
 
 
-def _new_compensating_for_off_resonance_with_a_sequence_with_sk_control(
+def _new_corpse_in_sk1_control(
     rabi_rotation: float,
     azimuthal_angle: float = 0.0,
     maximum_rabi_rate: float = 2.0 * np.pi,
@@ -745,7 +737,7 @@ def _new_corpse_in_scrofulous_control(
     )
 
 
-def _new_walsh_amplitude_modulated_filter_1_control(
+def _new_wamf1_control(
     rabi_rotation: float,
     azimuthal_angle: float = 0.0,
     maximum_rabi_rate: float = 2.0 * np.pi,


### PR DESCRIPTION
For the private function names I've opted to make them consistent with
the scheme names, since those are presumably the most natural ways to
refer to them.

Plan is to make the private functions public, and document those
functions with full details. Eventually we can probably delete the
new_predefined_driven_control, although it's fine to stick around for a
while for compatibility purposes.

https://q-ctrl.atlassian.net/browse/QENG-1118
