### PR TITLE
Fix scaling of amplitudes when exporting controls

### DIFF
--- a/qctrlopencontrols/driven_controls/driven_control.py
+++ b/qctrlopencontrols/driven_controls/driven_control.py
@@ -388,8 +388,8 @@ class DrivenControl:
                 for segment_idx in range(self.number_of_segments):
                     control_info.append(
                         "{},{},{},{},{}".format(
-                            amplitude_x[segment_idx],
-                            amplitude_y[segment_idx],
+                            amplitude_x[segment_idx] / self.maximum_rabi_rate,
+                            amplitude_y[segment_idx] / self.maximum_rabi_rate,
                             self.detunings[segment_idx],
                             self.durations[segment_idx],
                             self.maximum_rabi_rate,
@@ -400,8 +400,8 @@ class DrivenControl:
                 if self.name is not None:
                     control_info["name"] = self.name
                 control_info["maximum_rabi_rate"] = self.maximum_rabi_rate
-                control_info["amplitude_x"] = list(amplitude_x)
-                control_info["amplitude_y"] = list(amplitude_y)
+                control_info["amplitude_x"] = list(amplitude_x / self.maximum_rabi_rate)
+                control_info["amplitude_y"] = list(amplitude_y / self.maximum_rabi_rate)
                 control_info["detuning"] = list(self.detunings)
                 control_info["duration"] = list(self.durations)
 
@@ -416,9 +416,7 @@ class DrivenControl:
                     control_info.append(
                         "{},{},{},{},{}".format(
                             self.rabi_rates[segment_idx] / self.maximum_rabi_rate,
-                            np.arctan2(
-                                amplitude_y[segment_idx], amplitude_x[segment_idx]
-                            ),
+                            self.azimuthal_angles[segment_idx],
                             self.detunings[segment_idx],
                             self.durations[segment_idx],
                             self.maximum_rabi_rate,
@@ -433,9 +431,7 @@ class DrivenControl:
                 control_info["rabi_rates"] = list(
                     self.rabi_rates / self.maximum_rabi_rate
                 )
-                control_info["azimuthal_angles"] = list(
-                    np.arctan2(amplitude_y, amplitude_x)
-                )
+                control_info["azimuthal_angles"] = list(self.azimuthal_angles)
                 control_info["detuning"] = list(self.detunings)
                 control_info["duration"] = list(self.durations)
 


### PR DESCRIPTION
The amplitudes and Rabi rates are supposed to be given in proportion to
the maximum Rabi rate:
https://docs.q-ctrl.com/wiki/output-data-formats#q-ctrl-hardware

Also just use the azimuthal angles directly, rather than taking an arctan of
the amplitudes.

https://q-ctrl.atlassian.net/browse/QENG-1118
