### PR TITLE
 Use abbreviation in predefined DD functions

### DIFF
--- a/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
@@ -368,7 +368,7 @@ def new_spin_echo_sequence(duration=None, pre_post_rotation=False, **kwargs):
     )
 
 
-def new_carr_purcell_sequence(
+def new_cp_sequence(
     duration=None, number_of_offsets=None, pre_post_rotation=False, **kwargs
 ):
     """
@@ -434,7 +434,7 @@ def new_carr_purcell_sequence(
     )
 
 
-def new_carr_purcell_meiboom_gill_sequence(
+def new_cpmg_sequence(
     duration=None, number_of_offsets=None, pre_post_rotation=False, **kwargs
 ):
     """
@@ -501,7 +501,7 @@ def new_carr_purcell_meiboom_gill_sequence(
     )
 
 
-def new_uhrig_single_axis_sequence(
+def new_single_axis_uhrig_sequence(
     duration=None, number_of_offsets=None, pre_post_rotation=False, **kwargs
 ):
     """
@@ -568,7 +568,7 @@ def new_uhrig_single_axis_sequence(
     )
 
 
-def new_periodic_single_axis_sequence(
+def new_single_axis_periodic_sequence(
     duration=None, number_of_offsets=None, pre_post_rotation=False, **kwargs
 ):
     """
@@ -635,7 +635,7 @@ def new_periodic_single_axis_sequence(
     )
 
 
-def new_walsh_single_axis_sequence(
+def new_single_axis_walsh_sequence(
     duration=None, paley_order=None, pre_post_rotation=False, **kwargs
 ):
     """

--- a/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
@@ -200,7 +200,7 @@ def new_predefined_dds(scheme=SPIN_ECHO, **kwargs):
     elif scheme == SPIN_ECHO:
         sequence = new_spin_echo_sequence(**kwargs)
     elif scheme == CARR_PURCELL:
-        sequence = new_cp_sequence(**kwargs)
+        sequence = new_carr_purcell_sequence(**kwargs)
     elif scheme == CARR_PURCELL_MEIBOOM_GILL:
         sequence = new_cpmg_sequence(**kwargs)
     elif scheme == UHRIG_SINGLE_AXIS:
@@ -368,7 +368,7 @@ def new_spin_echo_sequence(duration=None, pre_post_rotation=False, **kwargs):
     )
 
 
-def new_cp_sequence(
+def new_carr_purcell_sequence(
     duration=None, number_of_offsets=None, pre_post_rotation=False, **kwargs
 ):
     """

--- a/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
@@ -187,7 +187,7 @@ def new_predefined_dds(scheme=SPIN_ECHO, **kwargs):
     Returns
     ------
     qctrlopencontrols.dynamic_decoupling_sequences.DynamicDecouplingSequence
-        A dynamical decuopling sequence corresponding to `scheme`.
+        A dynamical decoupling sequence corresponding to `scheme`.
 
     Raises
     -----
@@ -200,15 +200,15 @@ def new_predefined_dds(scheme=SPIN_ECHO, **kwargs):
     elif scheme == SPIN_ECHO:
         sequence = new_spin_echo_sequence(**kwargs)
     elif scheme == CARR_PURCELL:
-        sequence = new_carr_purcell_sequence(**kwargs)
+        sequence = new_cp_sequence(**kwargs)
     elif scheme == CARR_PURCELL_MEIBOOM_GILL:
-        sequence = new_carr_purcell_meiboom_gill_sequence(**kwargs)
+        sequence = new_cpmg_sequence(**kwargs)
     elif scheme == UHRIG_SINGLE_AXIS:
-        sequence = new_uhrig_single_axis_sequence(**kwargs)
+        sequence = new_single_axis_uhrig_sequence(**kwargs)
     elif scheme == PERIODIC_SINGLE_AXIS:
-        sequence = new_periodic_single_axis_sequence(**kwargs)
+        sequence = new_single_axis_periodic_sequence(**kwargs)
     elif scheme == WALSH_SINGLE_AXIS:
-        sequence = new_walsh_single_axis_sequence(**kwargs)
+        sequence = new_single_axis_walsh_sequence(**kwargs)
     elif scheme == QUADRATIC:
         sequence = new_quadratic_sequence(**kwargs)
     elif scheme == X_CONCATENATED:

--- a/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
@@ -142,15 +142,9 @@ def _add_pre_post_rotations(
     if (preserves_10 and preserves_11) or (not preserves_10 and not preserves_11):
         final_azimuthal = np.pi
 
-    offsets = np.insert(
-        offsets,
-        [0, offsets.shape[0]],
-        [0, duration],
-    )
+    offsets = np.insert(offsets, [0, offsets.shape[0]], [0, duration],)
     rabi_rotations = np.insert(
-        rabi_rotations,
-        [0, rabi_rotations.shape[0]],
-        [rabi_value, rabi_value],
+        rabi_rotations, [0, rabi_rotations.shape[0]], [rabi_value, rabi_value],
     )
     azimuthal_angles = np.insert(
         azimuthal_angles,

--- a/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
@@ -142,9 +142,15 @@ def _add_pre_post_rotations(
     if (preserves_10 and preserves_11) or (not preserves_10 and not preserves_11):
         final_azimuthal = np.pi
 
-    offsets = np.insert(offsets, [0, offsets.shape[0]], [0, duration],)
+    offsets = np.insert(
+        offsets,
+        [0, offsets.shape[0]],
+        [0, duration],
+    )
     rabi_rotations = np.insert(
-        rabi_rotations, [0, rabi_rotations.shape[0]], [rabi_value, rabi_value],
+        rabi_rotations,
+        [0, rabi_rotations.shape[0]],
+        [rabi_value, rabi_value],
     )
     azimuthal_angles = np.insert(
         azimuthal_angles,
@@ -204,11 +210,11 @@ def new_predefined_dds(scheme=SPIN_ECHO, **kwargs):
     elif scheme == CARR_PURCELL_MEIBOOM_GILL:
         sequence = new_cpmg_sequence(**kwargs)
     elif scheme == UHRIG_SINGLE_AXIS:
-        sequence = new_single_axis_uhrig_sequence(**kwargs)
+        sequence = new_uhrig_sequence(**kwargs)
     elif scheme == PERIODIC_SINGLE_AXIS:
-        sequence = new_single_axis_periodic_sequence(**kwargs)
+        sequence = new_periodic_sequence(**kwargs)
     elif scheme == WALSH_SINGLE_AXIS:
-        sequence = new_single_axis_walsh_sequence(**kwargs)
+        sequence = new_walsh_sequence(**kwargs)
     elif scheme == QUADRATIC:
         sequence = new_quadratic_sequence(**kwargs)
     elif scheme == X_CONCATENATED:
@@ -501,7 +507,7 @@ def new_cpmg_sequence(
     )
 
 
-def new_single_axis_uhrig_sequence(
+def new_uhrig_sequence(
     duration=None, number_of_offsets=None, pre_post_rotation=False, **kwargs
 ):
     """
@@ -568,7 +574,7 @@ def new_single_axis_uhrig_sequence(
     )
 
 
-def new_single_axis_periodic_sequence(
+def new_periodic_sequence(
     duration=None, number_of_offsets=None, pre_post_rotation=False, **kwargs
 ):
     """
@@ -635,7 +641,7 @@ def new_single_axis_periodic_sequence(
     )
 
 
-def new_single_axis_walsh_sequence(
+def new_walsh_sequence(
     duration=None, paley_order=None, pre_post_rotation=False, **kwargs
 ):
     """


### PR DESCRIPTION
- some name tweak
- fix typo

I guess spin echo is fine? (although in the doc we do call it `se`)