### PR TITLE
[Product 2318] Add doc to dynamical decoupling module

### DIFF
--- a/qctrlopencontrols/dynamic_decoupling_sequences/dynamic_decoupling_sequence.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/dynamic_decoupling_sequence.py
@@ -39,9 +39,8 @@ from ..utils import (
 
 
 class DynamicDecouplingSequence:
-    """
+    r"""
     Create a dynamic decoupling sequence.
-    Can be made of perfect operations, or realistic pulses.
 
     Parameters
     ----------
@@ -49,19 +48,19 @@ class DynamicDecouplingSequence:
         Defaults to 1. The total time in seconds for the sequence.
     offsets : np.ndarray
         Defaults to None.
-        The times offsets in s for the center of pulses.
+        The times offsets :math:`\{t_j\}` in seconds for the center of pulses.
         If None, defaults to one operation at halfway [0.5].
     rabi_rotations : np.ndarray
         Defaults to None.
-        The rabi rotations at each time offset.
-        If None, defaults to np.pi at each time offset.
+        The rabi rotation :math:`\omega_j` at each time offset :math:`t_j`.
+        If None, defaults to :math:`\pi` at each time offset.
     azimuthal_angles : np.ndarray
         Defaults to None.
-        The azimuthal angles at each time offset.
+        The azimuthal angle :math:`\phi_j` at each time offset :math:`t_j`.
         If None, defaults to 0 at each time offset.
     detuning_rotations : np.ndarray
         Defaults to None.
-        The detuning rotations at each time offset.
+        The detuning rotation :math:`\delta_j` at each time offset :math:`t_j`.
         If None, defaults to 0 at each time offset.
     name : str
         Name of the sequence. Defaults to None.
@@ -70,6 +69,23 @@ class DynamicDecouplingSequence:
     ------
     qctrlopencontrols.exceptions.ArgumentsValueError
         is raised if one of the inputs is invalid.
+
+    Notes
+    ____
+    Dynamical decoupling sequence (DDS) is canonically defined as a series of
+    :math:`n`-instantaneous unitary operations, often :math:`\pi`-pulses, executed
+    at time offsets :math:`\{t_j\}_{j=1}^n` over the time interval with a total
+    duration :math:`\tau`. The :math:`j`-the operation applied at time
+    :math:`t_j` can be parameterized as
+
+    .. math::
+        U_j = \exp\left[-\frac{i}{2}(\omega_j \cos \phi_j \sigma_x + \omega_j\sin \phi_j\sigma_y
+        + \delta_j\sigma_z)\right] \;,
+
+    Note that in practice all DDSs typically have a :math:`X_{\pi/2}` operation at the start and
+    end of the sequence. This is because it is assumed that the qubit is initially in the
+    state :math:`|0\rangle` and a superposition needs to be created and removed to make the qubit
+    sensitive to dephasing.
     """
 
     def __init__(

--- a/qctrlopencontrols/dynamic_decoupling_sequences/dynamic_decoupling_sequence.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/dynamic_decoupling_sequence.py
@@ -71,7 +71,7 @@ class DynamicDecouplingSequence:
         is raised if one of the inputs is invalid.
 
     Notes
-    ____
+    -----
     Dynamical decoupling sequence (DDS) is canonically defined as a series of
     :math:`n`-instantaneous unitary operations, often :math:`\pi`-pulses, executed
     at time offsets :math:`\{t_j\}_{j=1}^n` over the time interval with a total

--- a/qctrlopencontrols/dynamic_decoupling_sequences/dynamic_decoupling_sequence.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/dynamic_decoupling_sequence.py
@@ -75,7 +75,7 @@ class DynamicDecouplingSequence:
     Dynamical decoupling sequence (DDS) is canonically defined as a series of
     :math:`n`-instantaneous unitary operations, often :math:`\pi`-pulses, executed
     at time offsets :math:`\{t_j\}_{j=1}^n` over the time interval with a total
-    duration :math:`\tau`. The :math:`j`-the operation applied at time
+    duration :math:`\tau`. The :math:`j`-th operation applied at time
     :math:`t_j` can be parameterized as
 
     .. math::

--- a/qctrlopencontrols/dynamic_decoupling_sequences/dynamic_decoupling_sequence.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/dynamic_decoupling_sequence.py
@@ -45,7 +45,7 @@ class DynamicDecouplingSequence:
     Parameters
     ----------
     duration : float
-        Defaults to 1. The total time in seconds for the sequence.
+        Defaults to 1. The total time in seconds for the sequence :math:`\tau`.
     offsets : np.ndarray
         Defaults to None.
         The times offsets :math:`\{t_j\}` in seconds for the center of pulses.
@@ -83,7 +83,7 @@ class DynamicDecouplingSequence:
         + \delta_j\sigma_z)\right] \;,
 
     Note that in practice all DDSs typically have a :math:`X_{\pi/2}` operation at the start
-    :math:`t_0` and end :math:`t_\tau` of the sequence. This is because it is assumed that the
+    :math:`t = 0` and end :math:`t = \tau` of the sequence. This is because it is assumed that the
     qubit is initially in the state :math:`|0\rangle` and a superposition needs to be created and
     removed to make the qubit sensitive to dephasing.
     """

--- a/qctrlopencontrols/dynamic_decoupling_sequences/dynamic_decoupling_sequence.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/dynamic_decoupling_sequence.py
@@ -40,7 +40,7 @@ from ..utils import (
 
 class DynamicDecouplingSequence:
     r"""
-    Create a dynamic decoupling sequence.
+    Creates a dynamic decoupling sequence.
 
     Parameters
     ----------

--- a/qctrlopencontrols/dynamic_decoupling_sequences/dynamic_decoupling_sequence.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/dynamic_decoupling_sequence.py
@@ -82,10 +82,10 @@ class DynamicDecouplingSequence:
         U_j = \exp\left[-\frac{i}{2}(\omega_j \cos \phi_j \sigma_x + \omega_j\sin \phi_j\sigma_y
         + \delta_j\sigma_z)\right] \;,
 
-    Note that in practice all DDSs typically have a :math:`X_{\pi/2}` operation at the start and
-    end of the sequence. This is because it is assumed that the qubit is initially in the
-    state :math:`|0\rangle` and a superposition needs to be created and removed to make the qubit
-    sensitive to dephasing.
+    Note that in practice all DDSs typically have a :math:`X_{\pi/2}` operation at the start
+    :math:`t_0` and end :math:`t_\tau` of the sequence. This is because it is assumed that the
+    qubit is initially in the state :math:`|0\rangle` and a superposition needs to be created and
+    removed to make the qubit sensitive to dephasing.
     """
 
     def __init__(

--- a/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
@@ -301,7 +301,7 @@ def new_ramsey_sequence(duration=None, pre_post_rotation=False, **kwargs):
 
     References
     ----------
-    .. [#] `Norman F. Ramsey, Physical Review 78, 695 (1950)
+    .. [#] `N. F. Ramsey, Physical Review 78, 695 (1950).
         <https://link.aps.org/doi/10.1103/PhysRev.78.695>`_
     """
     duration = _check_duration(duration)
@@ -357,7 +357,7 @@ def new_spin_echo_sequence(duration=None, pre_post_rotation=False, **kwargs):
 
     References
     ----------
-    .. [#] `E. L. Hahn, Physical Review 80, 580 (1950)
+    .. [#] `E. L. Hahn, Physical Review 80, 580 (1950).
         <https://link.aps.org/doi/10.1103/PhysRev.80.580>`_
     """
 
@@ -426,13 +426,13 @@ def new_carr_purcell_sequence(
     operations applied at
 
     .. math::
-        t_i = \frac{\tau}{n} \left( \frac{1}{2} +i - 1\right) \;,
+        t_i = \frac{\tau}{n} \left(i -  \frac{1}{2}\right) \;,
 
     where :math:`i = 1, \cdots, n`.
 
     References
     ----------
-    .. [#] `H. Y. Carr and E. M. Purcell, Physical Review 94, 630 (1954)
+    .. [#] `H. Y. Carr and E. M. Purcell, Physical Review 94, 630 (1954).
         <https://link.aps.org/doi/10.1103/PhysRev.94.630>`_
     """
     duration = _check_duration(duration)
@@ -511,13 +511,13 @@ def new_cpmg_sequence(
     :math:`Y` axis. That is, it consists of :math:`Y_{\pi}` operations applied at times
 
     .. math::
-        t_i = \frac{\tau}{n} \left( \frac{1}{2} +i - 1\right) \;,
+        t_i = \frac{\tau}{n} \left(i - \frac{1}{2}\right) \;,
 
     where :math:`i = 1, \cdots, n`.
 
     References
     ----------
-    .. [#] `S. Meiboom and D. Gill, Review of Scientific Instruments 29:8, 688 (1958)
+    .. [#] `S. Meiboom and D. Gill, Review of Scientific Instruments 29:8, 688 (1958).
         <https://link.aps.org/doi/10.1063/1.1716296>`_
     """
     duration = _check_duration(duration)
@@ -598,7 +598,7 @@ def new_uhrig_sequence(
 
     References
     ----------
-    .. [#] `G. S. Uhrig, Physical Review Letters 98, 100504 (2007)
+    .. [#] `G. S. Uhrig, Physical Review Letters 98, 100504 (2007).
         <https://link.aps.org/doi/10.1103/PhysRevLett.98.100504>`_
     """
     duration = _check_duration(duration)
@@ -679,7 +679,7 @@ def new_periodic_sequence(
 
     References
     ----------
-    .. [#] `Lorenza Viola and Emanuel Knill, Physical Review Letters 90, 037901 (2003)
+    .. [#] `Lorenza Viola and Emanuel Knill, Physical Review Letters 90, 037901 (2003).
         <https://link.aps.org/doi/10.1103/PhysRevLett.90.037901>`_
     """
     duration = _check_duration(duration)
@@ -764,7 +764,7 @@ def new_walsh_sequence(
     .. math::
         {\rm PAL}_k(x) = \Pi_{j = 1}^m R_j(x)^{b_j} \;, \quad\; x \in [0, 1] \;.
 
-    where :math:`(b_m, b_{m-1}, \cdots, b_1)_2` is the binary representation of :math:`k`.
+    where :math:`(b_m, b_{m-1}, \cdots, b_1)` is the binary representation of :math:`k`.
     That is
 
     .. math::
@@ -781,10 +781,10 @@ def new_walsh_sequence(
 
     References
     ----------
-    .. [#] `H. Rademacher, Math. Ann. 87, 112–138 (1922)
+    .. [#] `H. Rademacher, Math. Ann. 87, 112–138 (1922).
         <https://doi.org/10.1007/BF01458040>`_
 
-    .. [#] `H. Ball and M. J Biercuk, EPJ Quantum Technol. 2, 11 (2015)
+    .. [#] `H. Ball and M. J Biercuk, EPJ Quantum Technol. 2, 11 (2015).
         <https://doi.org/10.1140/epjqt/s40507-015-0022-4>`_
     """
     duration = _check_duration(duration)
@@ -858,10 +858,8 @@ def new_quadratic_sequence(
         The total duration of the sequence :math:`\tau`.
     number_inner_offsets : int, optional
         Number of inner :math:`Z_{\pi}` pulses :math:`n_1`. Defaults to None.
-        Not used if number_of_offsets is supplied.
     number_outer_offsets : int, optional
         Number of outer :math:`X_{\pi}` pulses :math:`n_2`. Defaults to None.
-        Not used if number_of_offsets is supplied.
     pre_post_rotation : bool, optional
         If True, a :math:`X_{\pi/2}` rotation is added at the
         start and end of the sequence.
@@ -911,7 +909,7 @@ def new_quadratic_sequence(
     References
     ----------
     .. [#] `Jacob R. West, Bryan H. Fong, and Daniel A. Lidar,
-        Physical Review Letters 104, 130501 (2010)
+        Physical Review Letters 104, 130501 (2010).
         <https://doi.org/10.1103/PhysRevLett.104.130501>`_
     """
     duration = _check_duration(duration)
@@ -1027,7 +1025,7 @@ def new_x_concatenated_sequence(
     be denoted as :math:`C_l(\tau)`. In this scheme, zeroth order concatenation of duration
     :math:`\tau` is defined as free evolution over a period of :math:`\tau`. We use a notation
     of :math:`{\mathcal 1}(\tau)` to mean free evolution over duration :math:`\tau`.
-    We define the base DSS to be:
+    We define the base sequence to be:
 
     .. math::
         C_0(\tau) = {\mathcal 1}(\tau) \;.
@@ -1039,7 +1037,7 @@ def new_x_concatenated_sequence(
 
     References
     ----------
-    .. [#] `K. Khodjasteh and D. A. Lidar, Physical Review Letters 95, 180501 (2005)
+    .. [#] `K. Khodjasteh and D. A. Lidar, Physical Review Letters 95, 180501 (2005).
         <https://doi.org/10.1103/PhysRevLett.95.180501>`_
     """
     duration = _check_duration(duration)
@@ -1134,7 +1132,7 @@ def new_xy_concatenated_sequence(
     be denoted as :math:`C_l(\tau)`. In this scheme, zeroth order concatenation of duration
     :math:`\tau` is defined as free evolution over a period of :math:`\tau`. We use a notation
     of :math:`{\mathcal 1}(\tau)` to mean free evolution over duration :math:`\tau`.
-    We define the base DSS to be:
+    We define the base sequence to be:
 
     .. math::
         C_0(\tau) = {\mathcal 1}(\tau) \;.
@@ -1147,7 +1145,7 @@ def new_xy_concatenated_sequence(
 
     References
     ----------
-    .. [#] `K. Khodjasteh and D. A. Lidar, Physical Review Letters 95, 180501 (2005)
+    .. [#] `K. Khodjasteh and D. A. Lidar, Physical Review Letters 95, 180501 (2005).
         <https://doi.org/10.1103/PhysRevLett.95.180501>`_
 
     """

--- a/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
@@ -893,7 +893,7 @@ def new_quadratic_sequence(
     :math:`X_{\pi}` pulse, therefore has timing offset defined by
 
     .. math::
-        t_x^i = \tau \sin^2 \left[ \frac{i\pi}{2(n_2 + 1)}  \right] \;,
+        t_x^j = \tau \sin^2 \left[ \frac{j \pi}{2(n_2 + 1)}  \right] \;,
 
     where :math:`j = 1, \cdots, n_2`. On each sub-interval defined by the outer sequence,
     an inner sequence :math:`(Z_{\pi}^1, \cdots, Z_{\pi}^{n_1})` is implemented. The pulse times

--- a/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
@@ -1017,7 +1017,7 @@ def new_x_concatenated_sequence(
     Notes
     -----
     The :math:`X`-concatenated sequence is constructed by recursively concatenating
-    control seuqnce structures. It's parameterized by the concatenation order :math:`l` and
+    control sequence structures. It's parameterized by the concatenation order :math:`l` and
     the duration of the total sequence :math:`\tau`. Let the :math:`l`-th order of concatenation
     be denoted as :math:`C_l(\tau)`. In this scheme, zeroth order concatenation of duration
     :math:`\tau` is defined as free evolution over a period of :math:`\tau`. We use a notation

--- a/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
@@ -779,7 +779,7 @@ def new_walsh_sequence(
     .. [#] `H. Rademacher, Math. Ann. 87, 112–138 (1922)
         <https://doi.org/10.1007/BF01458040>`_
 
-    .. [#] `Harrison Ball & Michael J Biercuk, EPJ Quantum Technol. 2, 11 (2015)
+    .. [#] `H. Ball and M. J Biercuk, EPJ Quantum Technol. 2, 11 (2015)
         <https://doi.org/10.1140/epjqt/s40507-015-0022-4>`_
 
     Raises

--- a/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
@@ -1023,9 +1023,9 @@ def new_x_concatenated_sequence(
     control sequence structures. It's parameterized by the concatenation order :math:`l` and
     the duration of the total sequence :math:`\tau`. Let the :math:`l`-th order of concatenation
     be denoted as :math:`C_l(\tau)`. In this scheme, zeroth order concatenation of duration
-    :math:`\tau` is defined as free evolution over a period of :math:`\tau`. We use a notation
-    of :math:`{\mathcal 1}(\tau)` to mean free evolution over duration :math:`\tau`.
-    We define the base sequence to be:
+    :math:`\tau` is defined as free evolution over a period of :math:`\tau`. Using the notation
+    :math:`{\mathcal 1}(\tau)` to represent free evolution over duration :math:`\tau`, the
+    the base sequence is:
 
     .. math::
         C_0(\tau) = {\mathcal 1}(\tau) \;.

--- a/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
@@ -269,30 +269,35 @@ def _check_duration(duration: Optional[float] = None) -> float:
 
 
 def new_ramsey_sequence(duration=None, pre_post_rotation=False, **kwargs):
-    """
-    Creates Ramsey sequence.
+    r"""
+    Creates the Ramsey sequence.
 
     Parameters
     ----------
     duration : float, optional
-        Total duration of the sequence. Defaults to None
+        Total duration of the sequence :math:`\tau`. Defaults to None.
     pre_post_rotation : bool, optional
-        If True, a :math:`X_{\\pi.2}` rotation
+        If True, a :math:`X_{\pi / 2}` rotation
         is added at the start and end of the sequence.
     kwargs : dict
-        Additional keywords required by
-        qctrlopencontrols.sequences.DynamicDecouplingSequence
+        Additional keywords required by DynamicDecouplingSequence.
 
     Returns
     -------
-    qctrlopencontrols.dynamic_decoupling_sequences.DynamicDecouplingSequence
-        The Ramsey sequence
+    DynamicDecouplingSequence
+        The Ramsey sequence.
 
     Raises
     ------
     ArgumentsValueError
         Raised when an argument is invalid.
 
+    Notes
+    -----
+    Technically, the Ramsey sequence does not decouple the system from the environment.
+    Nevertheless, it is a useful sequence for characterization and testing protocols
+    and hence it is included. The sequence is parameterized by the duration :math:`\tau`
+    and contains no offsets in between the start and the end time of the sequence.
     """
     duration = _check_duration(duration)
     offsets = []
@@ -317,29 +322,33 @@ def new_ramsey_sequence(duration=None, pre_post_rotation=False, **kwargs):
 
 
 def new_spin_echo_sequence(duration=None, pre_post_rotation=False, **kwargs):
-    """
-    Creates Spin Echo Sequence.
+    r"""
+    Creates the spin echo sequence.
 
     Parameters
     ---------
     duration : float, optional
-        Total duration of the sequence. Defaults to None
+        Total duration of the sequence :math:`\tau`. Defaults to None.
     pre_post_rotation : bool, optional
-        If True, a :math:`\\pi.2` rotation is added at the
+        If True, a :math:`X_{\pi/2}` rotation is added at the
         start and end of the sequence.
     kwargs : dict
-        Additional keywords required by
-        qctrlopencontrols.sequences.DynamicDecouplingSequence
+        Additional keywords required by DynamicDecouplingSequence.
 
     Returns
     -------
-    qctrlopencontrols.dynamic_decoupling_sequences.DynamicDecouplingSequence
-        Spin echo sequence
+    DynamicDecouplingSequence
+        The spin echo sequence.
 
     Raises
     ------
     ArgumentsValueError
         Raised when an argument is invalid.
+
+    Notes
+    -----
+    The spin echo sequence is parameterized by duration :math:`\tau`. There is a single
+    :math:`X_{\pi}` unitary operation at :math:`t_1 = \frac{\tau}{2}`.
     """
 
     duration = _check_duration(duration)
@@ -371,26 +380,36 @@ def new_spin_echo_sequence(duration=None, pre_post_rotation=False, **kwargs):
 def new_carr_purcell_sequence(
     duration=None, number_of_offsets=None, pre_post_rotation=False, **kwargs
 ):
-    """
-    Creates Carr-Purcell Sequence.
+    r"""
+    Creates the Carr-Purcell sequence.
 
     Parameters
     ---------
     duration : float, optional
-        Total duration of the sequence. Defaults to None
+        Total duration of the sequence :math:`\tau`. Defaults to None.
     number_of_offsets : int, optional
-        Number of offsets. Defaults to None
+        Number of offsets :math:`n`. Defaults to None.
     pre_post_rotation : bool, optional
-        If True, a :math:`\\pi.2` rotation is added at the
+        If True, a :math:`X_{\pi/2}` rotation is added at the
         start and end of the sequence.
     kwargs : dict
-        Additional keywords required by
-        qctrlopencontrols.dynamical_decoupling_sequences.DynamicDecouplingSequence
+        Additional keywords required by DynamicDecouplingSequence.
 
     Returns
     -------
-    qctrlopencontrols.dynamical_decoupling_sequences.DynamicDecouplingSequence
-        Carr-Purcell sequence
+    DynamicDecouplingSequence
+        The Carr-Purcell sequence.
+
+    Notes
+    -----
+    The Carr-Purcell sequence is parameterized by the number of offsets :math:`n`
+    and duration :math:`\tau`. The sequence is made up of a set of :math:`X_{\pi}`
+    operations applied at
+
+    .. math::
+        t_i = \frac{\tau}{n} \left( \frac{1}{2} +i - 1\right) \;,
+
+    where :math:`i = 1, \cdots, n`.
 
     Raises
     ------
@@ -437,26 +456,36 @@ def new_carr_purcell_sequence(
 def new_cpmg_sequence(
     duration=None, number_of_offsets=None, pre_post_rotation=False, **kwargs
 ):
-    """
-    Creates Carr-Purcell-Meiboom-Gill Sequences.
+    r"""
+    Creates the Carr-Purcell-Meiboom-Gill sequence.
 
     Parameters
     ---------
     duration : float
-        Total duration of the sequence. Defaults to None
+        Total duration of the sequence :math:`\tau`. Defaults to None.
     number_of_offsets : int, optional
-        Number of offsets. Defaults to None
+        Number of offsets :math:`n`. Defaults to None.
     pre_post_rotation : bool, optional
-        If True, a :math:`\\pi.2` rotation is added at the
+        If True, a :math:`X_{\pi/2}` rotation is added at the
         start and end of the sequence.
     kwargs : dict
-        Additional keywords required by
-        qctrlopencontrols.dynamical_decoupling_sequences.DynamicDecouplingSequence
+        Additional keywords required by DynamicDecouplingSequence.
 
     Returns
     -------
-    qctrlopencontrols.dynamical_decoupling_sequences.DynamicDecouplingSequence
-        Carr-Purcell-Meiboom-Gill sequence
+    DynamicDecouplingSequence
+        The Carr-Purcell-Meiboom-Gill sequence.
+
+    Notes
+    -----
+    The Carr-Purcell-Meiboom-Gill (CPMG) sequence has the same timing and number of offsets as the
+    Carr-Purcell sequence. However, the intermediate :math:`Pi` rotations are applied along the
+    :math:`Y` axis. That is, it consists of :math:`Y_{\pi}` operations applied at times
+
+    .. math::
+        t_i = \frac{\tau}{n} \left( \frac{1}{2} +i - 1\right) \;,
+
+    where :math:`i = 1, \cdots, n`.
 
     Raises
     ------
@@ -504,26 +533,35 @@ def new_cpmg_sequence(
 def new_uhrig_sequence(
     duration=None, number_of_offsets=None, pre_post_rotation=False, **kwargs
 ):
-    """
-    Creates Uhrig Single Axis Sequence.
+    r"""
+    Creates the Uhrig sequence.
 
     Parameters
     ---------
     duration : float
-        Total duration of the sequence. Defaults to None
+        Total duration of the sequence :math:`\tau`. Defaults to None.
     number_of_offsets : int, optional
-        Number of offsets. Defaults to None
+        Number of offsets. Defaults to None.
     pre_post_rotation : bool, optional
-        If True, a :math:`\\pi.2` rotation is added at the
+        If True, a :math:`X_{\pi/2}` rotation is added at the
         start and end of the sequence.
     kwargs : dict
-        Additional keywords required by
-        qctrlopencontrols.dynamical_decoupling_sequences.DynamicDecouplingSequence
+        Additional keywords required by DynamicDecouplingSequence.
 
     Returns
     -------
-    qctrlopencontrols.dynamical_decoupling_sequences.DynamicDecouplingSequence
-        Uhrig (single-axis) sequence
+    DynamicDecouplingSequence
+        The Uhrig sequence.
+
+    Notes
+    -----
+    The Uhrig sequence is parameterized by duration :math:`\tau` and number of offsets :math:`n`.
+    The sequence consists of :math:`Y_{\pi}` operations at offsets given by
+
+    .. math::
+        t_i = \tau \sin^2 \left( \frac{i\pi}{2(n+1)} \right) \;,
+
+    where :math:`i = 1, \cdots, n`.
 
     Raises
     ------
@@ -577,11 +615,11 @@ def new_periodic_sequence(
     Parameters
     ---------
     duration : float
-        Total duration of the sequence. Defaults to None
+        Total duration of the sequence :math:`	au`. Defaults to None.
     number_of_offsets : int, optional
-        Number of offsets. Defaults to None
+        Number of offsets. Defaults to None.
     pre_post_rotation : bool, optional
-        If True, a :math:`\\pi.2` rotation is added at the
+        If True, a :math:`\pi/2` rotation is added at the
         start and end of the sequence.
     kwargs : dict
         Additional keywords required by
@@ -644,11 +682,11 @@ def new_walsh_sequence(
     Parameters
     ---------
     duration : float
-        Total duration of the sequence. Defaults to None
+        Total duration of the sequence :math:`	au`. Defaults to None.
     paley_order : int, optional
         Defaults to 1. The paley order of the walsh sequence.
     pre_post_rotation : bool, optional
-        If True, a :math:`\\pi.2` rotation is added at the
+        If True, a :math:`\pi/2` rotation is added at the
         start and end of the sequence.
     kwargs : dict
         Additional keywords required by
@@ -740,7 +778,7 @@ def new_quadratic_sequence(
         Number of inner Z-pi Pulses. Defaults to None. Not used if number_of_offsets
         is supplied
     pre_post_rotation : bool, optional
-        If True, a :math:`\\pi.2` rotation is added at the
+        If True, a :math:`\pi/2` rotation is added at the
         start and end of the sequence.
     kwargs : dict
         Additional keywords required by
@@ -843,7 +881,7 @@ def new_x_concatenated_sequence(
         defaults to None
         The number of concatenation of base sequence
     pre_post_rotation : bool, optional
-        If True, a :math:`\\pi.2` rotation is added at the
+        If True, a :math:`\pi/2` rotation is added at the
         start and end of the sequence.
     kwargs : dict
         Additional keywords required by
@@ -925,7 +963,7 @@ def new_xy_concatenated_sequence(
         defaults to None
         The number of concatenation of base sequence
     pre_post_rotation : bool, optional
-        If True, a :math:`\\pi.2` rotation is added at the
+        If True, a :math:`\pi/2` rotation is added at the
         start and end of the sequence.
     kwargs : dict
         Additional keywords required by

--- a/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
@@ -908,7 +908,7 @@ def new_quadratic_sequence(
 
     References
     ----------
-    .. [#] `Jacob R. West, Bryan H. Fong, and Daniel A. Lidar,
+    .. [#] `J. R. West, B. H. Fong, and D. A. Lidar,
         Physical Review Letters 104, 130501 (2010).
         <https://doi.org/10.1103/PhysRevLett.104.130501>`_
     """

--- a/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
@@ -731,7 +731,7 @@ def new_walsh_sequence(
     duration : float
         Total duration of the sequence :math:`\tau`. Defaults to None.
     paley_order : int, optional
-        The paley order :math:`k` of the walsh sequence. Defaults to 1.
+        The paley order :math:`k` of the Walsh sequence. Defaults to 1.
     pre_post_rotation : bool, optional
         If True, a :math:`X_{\pi/2}` rotation is added at the
         start and end of the sequence.

--- a/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
@@ -679,7 +679,7 @@ def new_periodic_sequence(
 
     References
     ----------
-    .. [#] `Lorenza Viola and Emanuel Knill, Physical Review Letters 90, 037901 (2003).
+    .. [#] `L. Viola and E. Knill, Physical Review Letters 90, 037901 (2003).
         <https://link.aps.org/doi/10.1103/PhysRevLett.90.037901>`_
     """
     duration = _check_duration(duration)

--- a/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
@@ -857,7 +857,7 @@ def new_quadratic_sequence(
         Defaults to None.
         The total duration of the sequence :math:`\tau`.
     number_inner_offsets : int, optional
-        Number of inner Z-pi Pulses :math:`n_1`. Defaults to None.
+        Number of inner Z :math:`\pi`-pulses :math:`n_1`. Defaults to None.
         Not used if number_of_offsets is supplied.
     number_outer_offsets : int, optional
         Number of outer X :math:`\pi`-pulses :math:`n_2`. Defaults to None.

--- a/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
@@ -410,6 +410,11 @@ def new_carr_purcell_sequence(
     DynamicDecouplingSequence
         The Carr-Purcell sequence.
 
+    Raises
+    ------
+    ArgumentsValueError
+        Raised when an argument is invalid.
+
     See Also
     --------
     new_cpmg_sequence
@@ -424,11 +429,6 @@ def new_carr_purcell_sequence(
         t_i = \frac{\tau}{n} \left( \frac{1}{2} +i - 1\right) \;,
 
     where :math:`i = 1, \cdots, n`.
-
-    Raises
-    ------
-    ArgumentsValueError
-        Raised when an argument is invalid.
 
     References
     ----------
@@ -495,6 +495,11 @@ def new_cpmg_sequence(
     DynamicDecouplingSequence
         The Carr-Purcell-Meiboom-Gill sequence.
 
+    Raises
+    ------
+    ArgumentsValueError
+        Raised when an argument is invalid.
+
     See Also
     --------
     new_carr_purcell_sequence
@@ -514,11 +519,6 @@ def new_cpmg_sequence(
     ----------
     .. [#] `S. Meiboom and D. Gill, Review of Scientific Instruments 29:8, 688 (1958)
         <https://link.aps.org/doi/10.1063/1.1716296>`_
-
-    Raises
-    ------
-    ArgumentsValueError
-        Raised when an argument is invalid.
     """
     duration = _check_duration(duration)
     number_of_offsets = number_of_offsets or 1
@@ -581,6 +581,11 @@ def new_uhrig_sequence(
     DynamicDecouplingSequence
         The Uhrig sequence.
 
+    Raises
+    ------
+    ArgumentsValueError
+        Raised when an argument is invalid.
+
     Notes
     -----
     The Uhrig sequence [#]_ is parameterized by duration :math:`\tau` and number of
@@ -595,11 +600,6 @@ def new_uhrig_sequence(
     ----------
     .. [#] `G. S. Uhrig, Physical Review Letters 98, 100504 (2007)
         <https://link.aps.org/doi/10.1103/PhysRevLett.98.100504>`_
-
-    Raises
-    ------
-    ArgumentsValueError
-        Raised when an argument is invalid.
     """
     duration = _check_duration(duration)
     number_of_offsets = number_of_offsets or 1
@@ -662,6 +662,11 @@ def new_periodic_sequence(
     DynamicDecouplingSequence
         The periodic sequence.
 
+    Raises
+    ------
+    ArgumentsValueError
+        Raised when an argument is invalid.
+
     Notes
     -----
     The periodic sequence [#]_ is parameterized by duration :math:`\tau` and number of
@@ -676,11 +681,6 @@ def new_periodic_sequence(
     ----------
     .. [#] `Lorenza Viola and Emanuel Knill, Physical Review Letters 90, 037901 (2003)
         <https://link.aps.org/doi/10.1103/PhysRevLett.90.037901>`_
-
-    Raises
-    ------
-    ArgumentsValueError
-        Raised when an argument is invalid.
     """
     duration = _check_duration(duration)
     number_of_offsets = number_of_offsets or 1
@@ -743,6 +743,11 @@ def new_walsh_sequence(
     DynamicDecouplingSequence
         The Walsh sequence.
 
+    Raises
+    ------
+    ArgumentsValueError
+        Raised when an argument is invalid.
+
     Notes
     -----
     The Walsh sequence is defined by the switching function :math:`y(t)` given by a
@@ -757,7 +762,7 @@ def new_walsh_sequence(
     function of Paley order :math:`k` is denoted :math:`{\rm PAL}_k(x)` and defined as
 
     .. math::
-        {\rm PAL}_k(x) = \Pi_{j = 1}^m R_j(x)^{b_j} \;, \quad\; x \ in [0, 1] \;.
+        {\rm PAL}_k(x) = \Pi_{j = 1}^m R_j(x)^{b_j} \;, \quad\; x \in [0, 1] \;.
 
     where :math:`(b_m, b_{m-1}, \cdots, b_1)_2` is the binary representation of :math:`k`.
     That is
@@ -781,11 +786,6 @@ def new_walsh_sequence(
 
     .. [#] `H. Ball and M. J Biercuk, EPJ Quantum Technol. 2, 11 (2015)
         <https://doi.org/10.1140/epjqt/s40507-015-0022-4>`_
-
-    Raises
-    ------
-    ArgumentsValueError
-        Raised when an argument is invalid.
     """
     duration = _check_duration(duration)
     paley_order = paley_order or 1
@@ -857,10 +857,10 @@ def new_quadratic_sequence(
         Defaults to None.
         The total duration of the sequence :math:`\tau`.
     number_inner_offsets : int, optional
-        Number of inner Z :math:`\pi`-pulses :math:`n_1`. Defaults to None.
+        Number of inner :math:`Z_{\pi}` pulses :math:`n_1`. Defaults to None.
         Not used if number_of_offsets is supplied.
     number_outer_offsets : int, optional
-        Number of outer X :math:`\pi`-pulses :math:`n_2`. Defaults to None.
+        Number of outer :math:`X_{\pi}` pulses :math:`n_2`. Defaults to None.
         Not used if number_of_offsets is supplied.
     pre_post_rotation : bool, optional
         If True, a :math:`X_{\pi/2}` rotation is added at the
@@ -872,6 +872,11 @@ def new_quadratic_sequence(
     -------
     DynamicDecouplingSequence
         The quadratic sequence.
+
+    Raises
+    ------
+    ArgumentsValueError
+        Raised when an argument is invalid.
 
     See Also
     --------
@@ -902,11 +907,6 @@ def new_quadratic_sequence(
                     + t_{x}^{j - 1} \;,
 
     where :math:`k = 1, \cdots, n_1` and :math:`j = 1, \cdots, n_2 + 1`.
-
-    Raises
-    ------
-    ArgumentsValueError
-        Raised when an argument is invalid.
 
     References
     ----------
@@ -1010,6 +1010,11 @@ def new_x_concatenated_sequence(
     DynamicDecouplingSequence
         The :math:`X`-concatenated sequence.
 
+    Raises
+    ------
+    ArgumentsValueError
+        Raised when an argument is invalid.
+
     See Also
     --------
     new_xy_concatenated_sequence
@@ -1036,11 +1041,6 @@ def new_x_concatenated_sequence(
     ----------
     .. [#] `K. Khodjasteh and D. A. Lidar, Physical Review Letters 95, 180501 (2005)
         <https://doi.org/10.1103/PhysRevLett.95.180501>`_
-
-    Raises
-    ------
-    ArgumentsValueError
-        Raised when an argument is invalid.
     """
     duration = _check_duration(duration)
 
@@ -1117,6 +1117,11 @@ def new_xy_concatenated_sequence(
     DynamicDecouplingSequence
         The :math:`XY`-concatenated sequence.
 
+    Raises
+    ------
+    ArgumentsValueError
+        Raised when an argument is invalid.
+
     See Also
     --------
     new_x_concatenated_sequence
@@ -1145,10 +1150,6 @@ def new_xy_concatenated_sequence(
     .. [#] `K. Khodjasteh and D. A. Lidar, Physical Review Letters 95, 180501 (2005)
         <https://doi.org/10.1103/PhysRevLett.95.180501>`_
 
-    Raises
-    ------
-    ArgumentsValueError
-        Raised when an argument is invalid.
     """
     duration = _check_duration(duration)
 

--- a/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
@@ -294,10 +294,15 @@ def new_ramsey_sequence(duration=None, pre_post_rotation=False, **kwargs):
 
     Notes
     -----
-    Technically, the Ramsey sequence does not decouple the system from the environment.
+    Technically, the Ramsey sequence [#]_ does not decouple the system from the environment.
     Nevertheless, it is a useful sequence for characterization and testing protocols
     and hence it is included. The sequence is parameterized by the duration :math:`\tau`
     and contains no offsets in between the start and the end time of the sequence.
+
+    References
+    ----------
+    .. [#] `Norman F. Ramsey, Physical Review 78, 695 (1950)
+        <https://link.aps.org/doi/10.1103/PhysRev.78.695>`_
     """
     duration = _check_duration(duration)
     offsets = []
@@ -347,8 +352,13 @@ def new_spin_echo_sequence(duration=None, pre_post_rotation=False, **kwargs):
 
     Notes
     -----
-    The spin echo sequence is parameterized by duration :math:`\tau`. There is a single
+    The spin echo sequence [#]_ is parameterized by duration :math:`\tau`. There is a single
     :math:`X_{\pi}` unitary operation at :math:`t_1 = \frac{\tau}{2}`.
+
+    References
+    ----------
+    .. [#] `E. L. Hahn, Physical Review 80, 580 (1950)
+        <https://link.aps.org/doi/10.1103/PhysRev.80.580>`_
     """
 
     duration = _check_duration(duration)
@@ -400,9 +410,13 @@ def new_carr_purcell_sequence(
     DynamicDecouplingSequence
         The Carr-Purcell sequence.
 
+    See Also
+    --------
+    new_cpmg_sequence
+
     Notes
     -----
-    The Carr-Purcell sequence is parameterized by the number of offsets :math:`n`
+    The Carr-Purcell sequence [#]_ is parameterized by the number of offsets :math:`n`
     and duration :math:`\tau`. The sequence is made up of a set of :math:`X_{\pi}`
     operations applied at
 
@@ -415,6 +429,11 @@ def new_carr_purcell_sequence(
     ------
     ArgumentsValueError
         Raised when an argument is invalid.
+
+    References
+    ----------
+    .. [#] `H. Y. Carr and E. M. Purcell, Physical Review 94, 630 (1954)
+        <https://link.aps.org/doi/10.1103/PhysRev.94.630>`_
     """
     duration = _check_duration(duration)
     number_of_offsets = number_of_offsets or 1
@@ -476,9 +495,13 @@ def new_cpmg_sequence(
     DynamicDecouplingSequence
         The Carr-Purcell-Meiboom-Gill sequence.
 
+    See Also
+    --------
+    new_carr_purcell_sequence
+
     Notes
     -----
-    The Carr-Purcell-Meiboom-Gill (CPMG) sequence has the same timing and number of offsets as the
+    The Carr-Purcell-Meiboom-Gill sequence [#]_ has the same timing and number of offsets as the
     Carr-Purcell sequence. However, the intermediate :math:`Pi` rotations are applied along the
     :math:`Y` axis. That is, it consists of :math:`Y_{\pi}` operations applied at times
 
@@ -486,6 +509,11 @@ def new_cpmg_sequence(
         t_i = \frac{\tau}{n} \left( \frac{1}{2} +i - 1\right) \;,
 
     where :math:`i = 1, \cdots, n`.
+
+    References
+    ----------
+    .. [#] `S. Meiboom and D. Gill, Review of Scientific Instruments 29:8, 688 (1958)
+        <https://link.aps.org/doi/10.1063/1.1716296>`_
 
     Raises
     ------
@@ -555,13 +583,18 @@ def new_uhrig_sequence(
 
     Notes
     -----
-    The Uhrig sequence is parameterized by duration :math:`\tau` and number of offsets :math:`n`.
-    The sequence consists of :math:`Y_{\pi}` operations at offsets given by
+    The Uhrig sequence [#]_ is parameterized by duration :math:`\tau` and number of
+    offsets :math:`n`. The sequence consists of :math:`Y_{\pi}` operations at offsets given by
 
     .. math::
         t_i = \tau \sin^2 \left( \frac{i\pi}{2(n+1)} \right) \;,
 
     where :math:`i = 1, \cdots, n`.
+
+    References
+    ----------
+    .. [#] `Götz S. Uhrig, Physical Review Letters 98, 100504 (2007)
+        <https://link.aps.org/doi/10.1103/PhysRevLett.98.100504>`_
 
     Raises
     ------
@@ -609,26 +642,40 @@ def new_uhrig_sequence(
 def new_periodic_sequence(
     duration=None, number_of_offsets=None, pre_post_rotation=False, **kwargs
 ):
-    """
-    Creates Periodic Single Axis Sequence.
+    r"""
+    Creates the periodic sequence.
 
     Parameters
     ---------
     duration : float
-        Total duration of the sequence :math:`	au`. Defaults to None.
+        Total duration of the sequence :math:`\tau`. Defaults to None.
     number_of_offsets : int, optional
-        Number of offsets. Defaults to None.
+        Number of offsets :math:`n`. Defaults to None.
     pre_post_rotation : bool, optional
-        If True, a :math:`\pi/2` rotation is added at the
+        If True, a :math:`X_{\pi/2}` rotation is added at the
         start and end of the sequence.
     kwargs : dict
-        Additional keywords required by
-        qctrlopencontrols.dynamical_decoupling_sequences.DynamicDecouplingSequence
+        Additional keywords required by DynamicDecouplingSequence.
 
     Returns
     -------
-    qctrlopencontrols.dynamical_decoupling_sequences.DynamicDecouplingSequence
-        Periodic (single-axis) sequence
+    DynamicDecouplingSequence
+        The periodic sequence.
+
+    Notes
+    -----
+    The periodic sequence [#]_ is parameterized by duration :math:`\tau` and number of
+    offsets :math:`n`. The sequence consists of :math:`X_{\pi}` operations at offsets given by
+
+    .. math::
+        t_i = \frac{\tau}{n + 1} \;,
+
+    where :math:`i = 1, \cdots, n`.
+
+    References
+    ----------
+    .. [#] `Lorenza Viola and Emanuel Knill, Physical Review Letters 90, 037901 (2003)
+        <https://link.aps.org/doi/10.1103/PhysRevLett.90.037901>`_
 
     Raises
     ------
@@ -676,26 +723,64 @@ def new_periodic_sequence(
 def new_walsh_sequence(
     duration=None, paley_order=None, pre_post_rotation=False, **kwargs
 ):
-    """
-    Creates Walsh Single Axis Sequence.
+    r"""
+    Creates the Walsh sequence.
 
     Parameters
     ---------
     duration : float
-        Total duration of the sequence :math:`	au`. Defaults to None.
+        Total duration of the sequence :math:`\tau`. Defaults to None.
     paley_order : int, optional
-        Defaults to 1. The paley order of the walsh sequence.
+        The paley order :math:`k` of the walsh sequence. Defaults to 1.
     pre_post_rotation : bool, optional
-        If True, a :math:`\pi/2` rotation is added at the
+        If True, a :math:`X_{\pi/2}` rotation is added at the
         start and end of the sequence.
     kwargs : dict
-        Additional keywords required by
-        qctrlopencontrols.dynamical_decoupling_sequences.DynamicDecouplingSequence
+        Additional keywords required by DynamicDecouplingSequence.
 
     Returns
     -------
-    qctrlopencontrols.dynamical_decoupling_sequences.DynamicDecouplingSequence
-        Walsh (single-axis) sequence
+    DynamicDecouplingSequence
+        The Walsh sequence.
+
+    Notes
+    -----
+    The Walsh sequence is defined by the switching function :math:`y(t)` given by a
+    Walsh function. To define the Walsh sequence, we first introduce the Rademacher
+    function [#]_, which is defined as
+
+    .. math::
+        R_j(x) := {\rm sgn}\left[\sin(2^j \pi x)\right] \;, \quad\; x \in [0, 1]\;, \; j \geq 0 \;.
+
+    The :math:`j`-th Rademacher function :math:`R_j(x)` is thus a periodic square wave switching
+    :math:`2^{j-1}` times between :math:`\pm 1` over the interval :math:`[0, 1]`. The Walsh
+    function of Paley order :math:`k` is denoted :math:`{\rm PAL}_k(x)` and defined as
+
+    .. math::
+        {\rm PAL}_k(x) = \Pi_{j = 1}^m R_j(x)^{b_j} \;, \quad\; x \ in [0, 1] \;.
+
+    where :math:`(b_m, b_{m-1}, \cdots, b_1)_2` is the binary representation of :math:`k`.
+    That is
+
+    .. math::
+        k = b_m 2^{m-1} + b_{m-1}2^{m-2} + \cdots + b_12^0 \;,
+
+    where :math:`m = m(k)` indexes the most significant binary bit of :math:`k`.
+
+    The :math:`k`-th order Walsh sequence [#]_ is then defined by
+
+    .. math::
+        y(t) = {\rm PAL}_k(t / \tau) \;
+
+    with offset times :math:`\{t_j / \tau\}` defined at the switching times of the Walsh function.
+
+    References
+    ----------
+    .. [#] `H. Rademacher, Math. Ann. 87, 112–138 (1922)
+        <https://doi.org/10.1007/BF01458040>`_
+
+    .. [#] `Harrison Ball & Michael J Biercuk, EPJ Quantum Technol. 2, 11 (2015)
+        <https://doi.org/10.1140/epjqt/s40507-015-0022-4>`_
 
     Raises
     ------
@@ -763,36 +848,71 @@ def new_quadratic_sequence(
     pre_post_rotation=False,
     **kwargs
 ):
-    """
-    Creates Quadratic Decoupling Sequence.
+    r"""
+    Creates the quadratic sequence.
 
     Parameters
     ----------
     duration : float, optional
-        defaults to None
-        The total duration of the sequence
-    number_outer_offsets : int, optional
-        Number of outer X-pi Pulses. Defaults to None. Not used if number_of_offsets
-        is supplied.
+        Defaults to None.
+        The total duration of the sequence :math:`\tau`.
     number_inner_offsets : int, optional
-        Number of inner Z-pi Pulses. Defaults to None. Not used if number_of_offsets
-        is supplied
+        Number of inner Z-pi Pulses :math:`n_1`. Defaults to None.
+        Not used if number_of_offsets is supplied.
+    number_outer_offsets : int, optional
+        Number of outer X-pi Pulses :math:`n_2`. Defaults to None.
+        Not used if number_of_offsets is supplied.
     pre_post_rotation : bool, optional
-        If True, a :math:`\pi/2` rotation is added at the
+        If True, a :math:`X_{\pi/2}` rotation is added at the
         start and end of the sequence.
     kwargs : dict
-        Additional keywords required by
-        qctrlopencontrols.dynamical_decoupling_sequences.DynamicDecouplingSequence
+        Additional keywords required by DynamicDecouplingSequence.
 
     Returns
     -------
-    qctrlopencontrols.dynamical_decoupling_sequences.DynamicDecouplingSequence
-        Quadratic sequence
+    DynamicDecouplingSequence
+        The quadratic sequence.
+
+    See Also
+    --------
+    new_uhrig_sequence
+
+    Notes
+    -----
+    The quadratic sequence [#]_ is parameterized by duration :math:`\tau`, number of inner offsets
+    :math:`n_1`, and number of outer offsets :math:`n_2`. The outer sequence consists of
+    :math:`n_2` pulses of type :math:`X_{\pi}`, which partition the time-domain into :math:`n_2+1`
+    sub-intervals on which inner sequences consisting of :math:`n_1` pulses of type
+    :math:`Z_{\pi}`are nested. The total number of offsets is :math:`n = n_1 + n_2(n_1 + 1)`.
+
+    The pulse times for outer sequence :math:`(X_{\pi}^1, \cdots, X_{\pi}^{n_2})` are defined
+    according to the Uhrig sequence for :math:`t \in [0, \tau]`. The :math:`j`-th
+    :math:`X_{\pi}` pulse, therefore has timing offset defined by
+
+    .. math::
+        t_x^i = \tau \sin^2 \left[ \frac{i\pi}{2(n_2 + 1)}  \right] \;,
+
+    where :math:`j = 1, \cdots, n_2`. On each sub-interval defined by the outer sequence,
+    an inner sequence :math:`(Z_{\pi}^1, \cdots, Z_{\pi}^{n_1})` is implemented. The pulse times
+    for the inner sequences are also defined according to the Uhrig sequence. The :math:`k`-th
+    pulse of the :math:`j`-th inner sequence has timing offset defined by
+
+    .. math::
+        t_z(k, j) = (t_x^j - t_x^{j - 1}) \sin^2 \left[ \frac{k \pi} {2 (n_1 + 1)} \right]
+                    + t_{x}^{j - 1} \;,
+
+    where :math:`k = 1, \cdots, n_1` and :math:`j = 1, \cdots, n_2 + 1`.
 
     Raises
     ------
     ArgumentsValueError
         Raised when an argument is invalid.
+
+    References
+    ----------
+    .. [#] `Jacob R. West, Bryan H. Fong, and Daniel A. Lidar,
+        Physical Review Letters 104, 130501 (2010)
+        <https://doi.org/10.1103/PhysRevLett.104.130501>`_
     """
     duration = _check_duration(duration)
 
@@ -868,29 +988,54 @@ def new_quadratic_sequence(
 def new_x_concatenated_sequence(
     duration=1.0, concatenation_order=None, pre_post_rotation=False, **kwargs
 ):
-    """
-    Creates X-Concatenated Dynamic Decoupling Sequence.
-    Concatenation of base sequence C(\tau/2)XC(\tau/2)X
+    r"""
+    Creates the :math:`X`-concatenated sequence.
 
     Parameters
     ----------
     duration : float, optional
-        defaults to None
-        The total duration of the sequence
+        Defaults to None.
+        The total duration of the sequence :math:`\tau`.
     concatenation_order : int, optional
-        defaults to None
-        The number of concatenation of base sequence
+        Defaults to None.
+        The number of concatenation of base sequence.
     pre_post_rotation : bool, optional
-        If True, a :math:`\pi/2` rotation is added at the
+        If True, a :math:`X_{\pi/2}` rotation is added at the
         start and end of the sequence.
     kwargs : dict
-        Additional keywords required by
-        qctrlopencontrols.dynamical_decoupling_sequences.DynamicDecouplingSequence
+        Additional keywords required by DynamicDecouplingSequence.
 
     Returns
     -------
-    qctrlopencontrols.dynamical_decoupling_sequences.DynamicDecouplingSequence
-        X concatenated sequence
+    DynamicDecouplingSequence
+        The :math:`X`-concatenated sequence.
+
+    See Also
+    --------
+    new_xy_concatenated_sequence
+
+    Notes
+    -----
+    The :math:`X`-concatenated sequence is constructed by recursively concatenating
+    control seuqnce structures. It's parameterized by the concatenation order :math:`l` and
+    the duration of the total sequence :math:`\tau`. Let the :math:`l`-th order of concatenation
+    be denoted as :math:`C_l(\tau)`. In this scheme, zeroth order concatenation of duration
+    :math:`\tau` is defined as free evolution over a period of :math:`\tau`. We use a notation
+    of :math:`{\mathcal 1}(\tau)` to mean free evolution over duration :math:`\tau`.
+    We define the base DSS to be:
+
+    .. math::
+        C_0(\tau) = {\mathcal 1}(\tau) \;.
+
+    The :math:`l`-th order :math:`X`-concatenated sequence can be recursively defined as
+
+    .. math::
+        C_l(\tau) = C_{l - 1}(\tau / 2) X_{\pi} C_{l - 1}(\tau / 2) X_{\pi} \;.
+
+    References
+    ----------
+    .. [#] `K. Khodjasteh and D. A. Lidar, Physical Review Letters 95, 180501 (2005)
+        <https://doi.org/10.1103/PhysRevLett.95.180501>`_
 
     Raises
     ------
@@ -950,29 +1095,55 @@ def new_x_concatenated_sequence(
 def new_xy_concatenated_sequence(
     duration=1.0, concatenation_order=None, pre_post_rotation=False, **kwargs
 ):
-    """
-    Creates XY-Concatenated Dynamic Decoupling Sequence.
-    Concatenation of base sequence C(\tau/4)XC(\tau/4)YC(\tau/4)XC(\tau/4)Y
+    r"""
+    Creates the :math:`XY`-Concatenated sequence.
 
     Parameters
     ----------
     duration : float, optional
-        defaults to None
-        The total duration of the sequence
+        Defaults to None.
+        The total duration of the sequence :math:`\tau`.
     concatenation_order : int, optional
-        defaults to None
-        The number of concatenation of base sequence
+        Defaults to None.
+        The number of concatenation of base sequence :math:`l`.
     pre_post_rotation : bool, optional
-        If True, a :math:`\pi/2` rotation is added at the
+        If True, a :math:`X_{\pi/2}` rotation is added at the
         start and end of the sequence.
     kwargs : dict
-        Additional keywords required by
-        qctrlopencontrols.dynamical_decoupling_sequences.DynamicDecouplingSequence
+        Additional keywords required by DynamicDecouplingSequence.
 
     Returns
     -------
-    qctrlopencontrols.dynamical_decoupling_sequences.DynamicDecouplingSequence
-        XY concatenated sequence.
+    DynamicDecouplingSequence
+        The :math:`XY`-concatenated sequence.
+
+    See Also
+    --------
+    new_x_concatenated_sequence
+
+    Notes
+    -----
+    The :math:`XY`-concatenated sequence is constructed by recursively concatenating
+    control sequence structures. It's parameterized by the concatenation order :math:`l` and
+    the duration of the total sequence :math:`\tau`. Let the :math:`l`-th order of concatenation
+    be denoted as :math:`C_l(\tau)`. In this scheme, zeroth order concatenation of duration
+    :math:`\tau` is defined as free evolution over a period of :math:`\tau`. We use a notation
+    of :math:`{\mathcal 1}(\tau)` to mean free evolution over duration :math:`\tau`.
+    We define the base DSS to be:
+
+    .. math::
+        C_0(\tau) = {\mathcal 1}(\tau) \;.
+
+    The :math:`l`-th order :math:`XY`-concatenated sequence can be recursively defined as
+
+    .. math::
+        C_l(\tau) = C_{l - 1}(\tau / 4) X_{\pi} C_{l - 1}(\tau / 4) Y_{\pi}
+                    C_{l - 1}(\tau / 4) X_{\pi} C_{l - 1}(\tau / 4) Y_{\pi} \;.
+
+    References
+    ----------
+    .. [#] `K. Khodjasteh and D. A. Lidar, Physical Review Letters 95, 180501 (2005)
+        <https://doi.org/10.1103/PhysRevLett.95.180501>`_
 
     Raises
     ------

--- a/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
@@ -593,7 +593,7 @@ def new_uhrig_sequence(
 
     References
     ----------
-    .. [#] `Götz S. Uhrig, Physical Review Letters 98, 100504 (2007)
+    .. [#] `G. S. Uhrig, Physical Review Letters 98, 100504 (2007)
         <https://link.aps.org/doi/10.1103/PhysRevLett.98.100504>`_
 
     Raises

--- a/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
@@ -1130,9 +1130,9 @@ def new_xy_concatenated_sequence(
     control sequence structures. It's parameterized by the concatenation order :math:`l` and
     the duration of the total sequence :math:`\tau`. Let the :math:`l`-th order of concatenation
     be denoted as :math:`C_l(\tau)`. In this scheme, zeroth order concatenation of duration
-    :math:`\tau` is defined as free evolution over a period of :math:`\tau`. We use a notation
-    of :math:`{\mathcal 1}(\tau)` to mean free evolution over duration :math:`\tau`.
-    We define the base sequence to be:
+    :math:`\tau` is defined as free evolution over a period of :math:`\tau`. Using the notation
+    :math:`{\mathcal 1}(\tau)` to represent free evolution over duration :math:`\tau`, the
+    the base sequence is:
 
     .. math::
         C_0(\tau) = {\mathcal 1}(\tau) \;.

--- a/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
@@ -886,7 +886,7 @@ def new_quadratic_sequence(
     :math:`n_1`, and number of outer offsets :math:`n_2`. The outer sequence consists of
     :math:`n_2` pulses of type :math:`X_{\pi}`, which partition the time-domain into :math:`n_2+1`
     sub-intervals on which inner sequences consisting of :math:`n_1` pulses of type
-    :math:`Z_{\pi}`are nested. The total number of offsets is :math:`n = n_1 + n_2(n_1 + 1)`.
+    :math:`Z_{\pi}` are nested. The total number of offsets is :math:`n = n_1 + n_2(n_1 + 1)`.
 
     The pulse times for outer sequence :math:`(X_{\pi}^1, \cdots, X_{\pi}^{n_2})` are defined
     according to the Uhrig sequence for :math:`t \in [0, \tau]`. The :math:`j`-th

--- a/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
@@ -860,7 +860,7 @@ def new_quadratic_sequence(
         Number of inner Z-pi Pulses :math:`n_1`. Defaults to None.
         Not used if number_of_offsets is supplied.
     number_outer_offsets : int, optional
-        Number of outer X-pi Pulses :math:`n_2`. Defaults to None.
+        Number of outer X :math:`\pi`-pulses :math:`n_2`. Defaults to None.
         Not used if number_of_offsets is supplied.
     pre_post_rotation : bool, optional
         If True, a :math:`X_{\pi/2}` rotation is added at the

--- a/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
@@ -502,7 +502,7 @@ def new_cpmg_sequence(
     Notes
     -----
     The Carr-Purcell-Meiboom-Gill sequence [#]_ has the same timing and number of offsets as the
-    Carr-Purcell sequence. However, the intermediate :math:`Pi` rotations are applied along the
+    Carr-Purcell sequence. However, the intermediate :math:`\pi` rotations are applied along the
     :math:`Y` axis. That is, it consists of :math:`Y_{\pi}` operations applied at times
 
     .. math::


### PR DESCRIPTION
This PR moves the doc from wiki to the dynamical decoupling module.
Most of the content would be the same as shown in https://docs.q-ctrl.com/wiki/control-library,
except for the doc of the Walsh sequence, where I added a bit more details from the internal document.

You may find some of the default values do not make much sense. I have a plan to fix this later.
This PR would mainly just migrate the doc.

Preview:
https://product-2318.docs.q-ctrl.com/references/python/qctrl-open-controls/qctrlopencontrols.html