### PR TITLE
Refactor `DynamicDecouplingSequence`

### DIFF
--- a/tests/test_dynamical_decoupling.py
+++ b/tests/test_dynamical_decoupling.py
@@ -206,6 +206,7 @@ def test_pretty_string_format():
     _name = "test_sequence"
 
     dd_sequence = DynamicDecouplingSequence(
+        duration=_duration,
         offsets=_offsets,
         rabi_rotations=_rabi_rotations,
         azimuthal_angles=_azimuthal_angles,
@@ -247,6 +248,7 @@ def test_pretty_string_format():
     assert _pretty_string == str(dd_sequence)
 
     dd_sequence = DynamicDecouplingSequence(
+        duration=_duration,
         offsets=_offsets,
         rabi_rotations=_rabi_rotations,
         azimuthal_angles=_azimuthal_angles,

--- a/tests/test_dynamical_decoupling.py
+++ b/tests/test_dynamical_decoupling.py
@@ -125,7 +125,9 @@ def test_dynamical_decoupling_sequence():
         )
 
         # duration cannot be negative
-        _ = DynamicDecouplingSequence(duration=-2.0)
+        _ = DynamicDecouplingSequence(
+            duration=-2.0, offsets=2.0 / 2000 * np.ones((20000, 1))
+        )
 
 
 def test_sequence_plot():


### PR DESCRIPTION
This PR mainly focuses on the value-checking of `DynamicDecouplingSequence`.

`duration` and `offsets` are now not optional as I can't find a good reason/way to do it. Note that:
 1.  following inputs, like `rabi_rotations`, depend on `offsets` if they are not provided.
 2.  use 1 and [0.5] as default values for `duration` and `offsets` just feel wrong.
 3. I think they were there because of the old design of Black Opal. Functions in this repo are obsessed to have default values all the time.

If you agree with this change, I would propose to also make duration as non-optional input for functions in the predefined module.

`number_of_offsets` is also removed as it was used for value checking.