### PR TITLE
Change varibale name using Q-CTRL standard

### DIFF
--- a/examples/creating-a-dynamical-decoupling-sequence.ipynb
+++ b/examples/creating-a-dynamical-decoupling-sequence.ipynb
@@ -108,10 +108,10 @@
      "text": [
       "CP DDS:\n",
       "Duration = 1e-05\n",
-      "Offsets = [0.125,0.375,0.625,0.875] x 1e-05\n",
-      "Rabi Rotations = [1.0,1.0,1.0,1.0] x pi\n",
-      "Azimuthal Angles = [0.0,0.0,0.0,0.0] x pi\n",
-      "Detuning Rotations = [0.0,0.0,0.0,0.0] x pi\n"
+      "Offsets = [0.125, 0.375, 0.625, 0.875] x 1e-05\n",
+      "Rabi Rotations = [1.0, 1.0, 1.0, 1.0] x pi\n",
+      "Azimuthal Angles = [0.0, 0.0, 0.0, 0.0] x pi\n",
+      "Detuning Rotations = [0.0, 0.0, 0.0, 0.0] x pi\n"
      ]
     }
    ],
@@ -119,7 +119,7 @@
     "## Carr-Purcell sequence\n",
     "cp_dds = new_carr_purcell_sequence( \n",
     "    duration=10e-6, \n",
-    "    number_of_offsets = 4.,\n",
+    "    offset_count = 4.,\n",
     "    name='CP DDS')\n",
     "print(cp_dds)"
    ]
@@ -135,10 +135,10 @@
      "text": [
       "Walsh DDS:\n",
       "Duration = 1e-05\n",
-      "Offsets = [0.125,0.25,0.375,0.5,0.625,0.75,0.875] x 1e-05\n",
-      "Rabi Rotations = [1.0,1.0,1.0,1.0,1.0,1.0,1.0] x pi\n",
-      "Azimuthal Angles = [0.0,0.0,0.0,0.0,0.0,0.0,0.0] x pi\n",
-      "Detuning Rotations = [0.0,0.0,0.0,0.0,0.0,0.0,0.0] x pi\n"
+      "Offsets = [0.125, 0.25, 0.375, 0.5, 0.625, 0.75, 0.875] x 1e-05\n",
+      "Rabi Rotations = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0] x pi\n",
+      "Azimuthal Angles = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0] x pi\n",
+      "Detuning Rotations = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0] x pi\n"
      ]
     }
    ],
@@ -162,10 +162,10 @@
      "text": [
       "Quadratic DDS:\n",
       "Duration = 1e-05\n",
-      "Offsets = [0.06249999999999998,0.18749999999999994,0.24999999999999994,0.37499999999999994,0.6249999999999999,0.7499999999999999,0.8124999999999999,0.9375] x 1e-05\n",
-      "Rabi Rotations = [0.0,0.0,1.0,0.0,0.0,1.0,0.0,0.0] x pi\n",
-      "Azimuthal Angles = [0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0] x pi\n",
-      "Detuning Rotations = [1.0,1.0,0.0,1.0,1.0,0.0,1.0,1.0] x pi\n"
+      "Offsets = [0.06249999999999998, 0.18749999999999994, 0.24999999999999994, 0.37499999999999994, 0.6249999999999999, 0.7499999999999999, 0.8124999999999999, 0.9375] x 1e-05\n",
+      "Rabi Rotations = [0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0] x pi\n",
+      "Azimuthal Angles = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0] x pi\n",
+      "Detuning Rotations = [1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0] x pi\n"
      ]
     }
    ],
@@ -173,8 +173,8 @@
     "## Quadratic sequence\n",
     "quadratic_dds = new_quadratic_sequence(\n",
     "    duration=10e-6, \n",
-    "    number_inner_offsets = 2,\n",
-    "    number_outer_offsets = 2,\n",
+    "    inner_offset_count = 2,\n",
+    "    outer_offset_count = 2,\n",
     "    name='Quadratic DDS')\n",
     "print(quadratic_dds)"
    ]
@@ -190,10 +190,10 @@
      "text": [
       "XC DDS:\n",
       "Duration = 1e-05\n",
-      "Offsets = [0.25,0.75] x 1e-05\n",
-      "Rabi Rotations = [1.0,1.0] x pi\n",
-      "Azimuthal Angles = [0.0,0.0] x pi\n",
-      "Detuning Rotations = [0.0,0.0] x pi\n"
+      "Offsets = [0.25, 0.75] x 1e-05\n",
+      "Rabi Rotations = [1.0, 1.0] x pi\n",
+      "Azimuthal Angles = [0.0, 0.0] x pi\n",
+      "Detuning Rotations = [0.0, 0.0] x pi\n"
      ]
     }
    ],

--- a/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
@@ -260,7 +260,7 @@ def new_spin_echo_sequence(duration, pre_post_rotation=False, name=None):
 
 
 def new_carr_purcell_sequence(
-    duration, number_of_offsets, pre_post_rotation=False, name=None
+    duration, offset_count, pre_post_rotation=False, name=None
 ):
     r"""
     Creates the Carr-Purcell sequence.
@@ -269,7 +269,7 @@ def new_carr_purcell_sequence(
     ----------
     duration : float
         Total duration of the sequence :math:`\tau` (in seconds).
-    number_of_offsets : int
+    offset_count : int
         Number of offsets :math:`n`.
     pre_post_rotation : bool, optional
         If ``True``, a :math:`X_{\pi/2}` rotation is added at the
@@ -309,14 +309,14 @@ def new_carr_purcell_sequence(
         {"duration": duration},
     )
     check_arguments(
-        number_of_offsets >= 1,
+        offset_count >= 1,
         "Number of offsets must be greater than zero.",
-        {"number_of_offsets": number_of_offsets},
+        {"offset_count": offset_count},
     )
 
     # in case a float number is passed
-    number_of_offsets = int(number_of_offsets)
-    offsets = _carr_purcell_meiboom_gill_offsets(duration, number_of_offsets)
+    offset_count = int(offset_count)
+    offsets = _carr_purcell_meiboom_gill_offsets(duration, offset_count)
 
     rabi_rotations = np.zeros(offsets.shape)
     # set all as X_pi
@@ -344,7 +344,7 @@ def new_carr_purcell_sequence(
     )
 
 
-def new_cpmg_sequence(duration, number_of_offsets, pre_post_rotation=False, name=None):
+def new_cpmg_sequence(duration, offset_count, pre_post_rotation=False, name=None):
     r"""
     Creates the Carr-Purcell-Meiboom-Gill sequence.
 
@@ -352,7 +352,7 @@ def new_cpmg_sequence(duration, number_of_offsets, pre_post_rotation=False, name
     ----------
     duration : float
         Total duration of the sequence :math:`\tau` (in seconds).
-    number_of_offsets : int
+    offset_count : int
         Number of offsets :math:`n`.
     pre_post_rotation : bool, optional
         If ``True``, a :math:`X_{\pi/2}` rotation is added at the
@@ -392,14 +392,14 @@ def new_cpmg_sequence(duration, number_of_offsets, pre_post_rotation=False, name
         {"duration": duration},
     )
     check_arguments(
-        number_of_offsets >= 1,
+        offset_count >= 1,
         "Number of offsets must be greater than zero.",
-        {"number_of_offsets": number_of_offsets},
+        {"offset_count": offset_count},
     )
 
     # in case a float number is passed
-    number_of_offsets = int(number_of_offsets)
-    offsets = _carr_purcell_meiboom_gill_offsets(duration, number_of_offsets)
+    offset_count = int(offset_count)
+    offsets = _carr_purcell_meiboom_gill_offsets(duration, offset_count)
     rabi_rotations = np.zeros(offsets.shape)
     azimuthal_angles = np.zeros(offsets.shape)
 
@@ -428,7 +428,7 @@ def new_cpmg_sequence(duration, number_of_offsets, pre_post_rotation=False, name
     )
 
 
-def new_uhrig_sequence(duration, number_of_offsets, pre_post_rotation=False, name=None):
+def new_uhrig_sequence(duration, offset_count, pre_post_rotation=False, name=None):
     r"""
     Creates the Uhrig sequence.
 
@@ -436,7 +436,7 @@ def new_uhrig_sequence(duration, number_of_offsets, pre_post_rotation=False, nam
     ----------
     duration : float
         Total duration of the sequence :math:`\tau` (in seconds).
-    number_of_offsets : int
+    offset_count : int
         Number of offsets :math:`n`.
     pre_post_rotation : bool, optional
         If ``True``, a :math:`X_{\pi/2}` rotation is added at the
@@ -471,14 +471,14 @@ def new_uhrig_sequence(duration, number_of_offsets, pre_post_rotation=False, nam
         {"duration": duration},
     )
     check_arguments(
-        number_of_offsets >= 1,
+        offset_count >= 1,
         "Number of offsets must be greater than zero.",
-        {"number_of_offsets": number_of_offsets},
+        {"offset_count": offset_count},
     )
 
     # in case a float number is passed
-    number_of_offsets = int(number_of_offsets)
-    offsets = _uhrig_single_axis_offsets(duration, number_of_offsets)
+    offset_count = int(offset_count)
+    offsets = _uhrig_single_axis_offsets(duration, offset_count)
     rabi_rotations = np.zeros(offsets.shape)
     azimuthal_angles = np.zeros(offsets.shape)
 
@@ -507,9 +507,7 @@ def new_uhrig_sequence(duration, number_of_offsets, pre_post_rotation=False, nam
     )
 
 
-def new_periodic_sequence(
-    duration, number_of_offsets, pre_post_rotation=False, name=None
-):
+def new_periodic_sequence(duration, offset_count, pre_post_rotation=False, name=None):
     r"""
     Creates the periodic sequence.
 
@@ -517,7 +515,7 @@ def new_periodic_sequence(
     ----------
     duration : float
         Total duration of the sequence :math:`\tau` (in seconds).
-    number_of_offsets : int
+    offset_count : int
         Number of offsets :math:`n`.
     pre_post_rotation : bool, optional
         If ``True``, a :math:`X_{\pi/2}` rotation is added at the
@@ -552,16 +550,16 @@ def new_periodic_sequence(
         {"duration": duration},
     )
     check_arguments(
-        number_of_offsets >= 1,
+        offset_count >= 1,
         "Number of offsets must be greater than zero.",
-        {"number_of_offsets": number_of_offsets},
+        {"offset_count": offset_count},
     )
 
     # in case a float number is passed
-    number_of_offsets = int(number_of_offsets)
+    offset_count = int(offset_count)
 
-    spacing = 1.0 / (number_of_offsets + 1)
-    deltas = np.array([k * spacing for k in range(1, number_of_offsets + 1)])
+    spacing = 1.0 / (offset_count + 1)
+    deltas = np.array([k * spacing for k in range(1, offset_count + 1)])
     offsets = duration * deltas
     rabi_rotations = np.zeros(offsets.shape)
     rabi_rotations[0:] = np.pi
@@ -711,8 +709,8 @@ def new_walsh_sequence(duration, paley_order, pre_post_rotation=False, name=None
 
 def new_quadratic_sequence(
     duration,
-    number_inner_offsets,
-    number_outer_offsets,
+    inner_offset_count,
+    outer_offset_count,
     pre_post_rotation=False,
     name=None,
 ):
@@ -723,9 +721,9 @@ def new_quadratic_sequence(
     ----------
     duration : float
         The total duration of the sequence :math:`\tau` (in seconds).
-    number_inner_offsets : int
+    inner_offset_count : int
         Number of inner :math:`Z_{\pi}` pulses :math:`n_1`.
-    number_outer_offsets : int
+    outer_offset_count : int
         Number of outer :math:`X_{\pi}` pulses :math:`n_2`.
     pre_post_rotation : bool, optional
         If ``True``, a :math:`X_{\pi/2}` rotation is added at the
@@ -781,39 +779,39 @@ def new_quadratic_sequence(
         {"duration": duration},
     )
     check_arguments(
-        number_inner_offsets >= 1,
+        inner_offset_count >= 1,
         "Number of offsets of inner pulses must be greater than zero.",
-        {"number_inner_offsets": number_inner_offsets},
+        {"inner_offset_count": inner_offset_count},
     )
     check_arguments(
-        number_outer_offsets >= 1,
+        outer_offset_count >= 1,
         "Number of offsets of outer pulses must be greater than zero.",
-        {"number_outer_offsets": number_outer_offsets},
+        {"outer_offset_count": outer_offset_count},
     )
 
-    number_inner_offsets = int(number_inner_offsets)
-    number_outer_offsets = int(number_outer_offsets)
-    outer_offsets = _uhrig_single_axis_offsets(duration, number_outer_offsets)
+    inner_offset_count = int(inner_offset_count)
+    outer_offset_count = int(outer_offset_count)
+    outer_offsets = _uhrig_single_axis_offsets(duration, outer_offset_count)
     outer_offsets = np.insert(outer_offsets, [0, len(outer_offsets)], [0, duration])
 
     inner_durations = np.diff(outer_offsets)
 
     # offsets include inner and outer offsets
     # the extra 1 dimension in columns is where we add the outer offset back
-    offsets = np.zeros((len(inner_durations), number_inner_offsets + 1))
+    offsets = np.zeros((len(inner_durations), inner_offset_count + 1))
     for inner_duration_idx, inner_duration in enumerate(inner_durations):
         inner_offset = (
-            _uhrig_single_axis_offsets(inner_duration, number_inner_offsets)
+            _uhrig_single_axis_offsets(inner_duration, inner_offset_count)
             + outer_offsets[inner_duration_idx]
         )
-        offsets[inner_duration_idx, 0:number_inner_offsets] = inner_offset
+        offsets[inner_duration_idx, 0:inner_offset_count] = inner_offset
     offsets[:, -1] = outer_offsets[1:]
 
     rabi_rotations = np.zeros(offsets.shape)
     detuning_rotations = np.zeros(offsets.shape)
 
-    rabi_rotations[0:number_outer_offsets, -1] = np.pi
-    detuning_rotations[0 : (number_outer_offsets + 1), 0:number_inner_offsets] = np.pi
+    rabi_rotations[0:outer_offset_count, -1] = np.pi
+    detuning_rotations[0 : (outer_offset_count + 1), 0:inner_offset_count] = np.pi
 
     offsets = offsets.flatten()
     rabi_rotations = rabi_rotations.flatten()
@@ -1129,7 +1127,7 @@ def new_xy_concatenated_sequence(
 
 
 def _carr_purcell_meiboom_gill_offsets(
-    duration: float = 1.0, number_of_offsets: int = 1
+    duration: float = 1.0, offset_count: int = 1
 ) -> np.ndarray:
     """
     Calculates offset values for Carr-Purcell_Meiboom-Gill sequence.
@@ -1138,7 +1136,7 @@ def _carr_purcell_meiboom_gill_offsets(
     ----------
     duration : float, optional
         Duration of the total sequence. Defaults to 1.0.
-    number_of_offsets : int, optional
+    offset_count : int, optional
         The number of offsets. Defaults to 1.
 
     Returns
@@ -1147,29 +1145,27 @@ def _carr_purcell_meiboom_gill_offsets(
         The offset values
     """
 
-    spacing = 1.0 / number_of_offsets
+    spacing = 1.0 / offset_count
     start = spacing * 0.5
 
     # prepare the offsets for delta comb
-    deltas = spacing * np.arange(number_of_offsets)
+    deltas = spacing * np.arange(offset_count)
     deltas += start
     offsets = deltas * duration
 
     return offsets
 
 
-def _uhrig_single_axis_offsets(
-    duration: float = 1.0, number_of_offsets: int = 1
-) -> np.ndarray:
+def _uhrig_single_axis_offsets(duration: float, offset_count: int) -> np.ndarray:
     """
     Calculates oOffset values for Uhrig Single Axis Sequence.
 
     Parameters
     ----------
-    duration : float, optional
-        Duration of the total sequence. Defaults to 1.0.
-    number_of_offsets : int, optional
-        The number of offsets. Defaults to 1.
+    duration : float
+        Duration of the total sequence.
+    offset_count : int, optional
+        The number of offsets.
 
     Returns
     -------
@@ -1178,24 +1174,24 @@ def _uhrig_single_axis_offsets(
     """
 
     # prepare the offsets for delta comb
-    constant = 1.0 / (2 * number_of_offsets + 2)
+    constant = 1.0 / (2 * offset_count + 2)
     deltas = np.array(
-        [(np.sin(np.pi * k * constant)) ** 2 for k in range(1, number_of_offsets + 1)]
+        [(np.sin(np.pi * k * constant)) ** 2 for k in range(1, offset_count + 1)]
     )
     offsets = duration * deltas
 
     return offsets
 
 
-def _concatenation_x(concatenation_sequence: int = 1) -> np.ndarray:
+def _concatenation_x(concatenation_sequence: int) -> np.ndarray:
     """
     Prepares the sequence of operations for x-concatenated
     dynamical decoupling sequence.
 
     Parameters
     ----------
-    concatenation_sequence : int, optional
-        Duration of the total sequence. Defaults to 1.
+    concatenation_sequence : int
+        Duration of the total sequence.
 
     Returns
     -------
@@ -1217,15 +1213,15 @@ def _concatenation_x(concatenation_sequence: int = 1) -> np.ndarray:
     )
 
 
-def _concatenation_xy(concatenation_sequence: int = 1) -> np.ndarray:
+def _concatenation_xy(concatenation_sequence) -> np.ndarray:
     """
     Prepares the sequence of operations for x-concatenated
     dynamical decoupling sequence.
 
     Parameters
     ----------
-    concatenation_sequence : int, optional
-        Duration of the total sequence. Defaults to 1.
+    concatenation_sequence : int
+        Duration of the total sequence.
 
     Returns
     -------

--- a/tests/test_predefined_dynamical_decoupling.py
+++ b/tests/test_predefined_dynamical_decoupling.py
@@ -108,13 +108,13 @@ def test_carr_purcell_sequence():
     """
 
     duration = 10.0
-    number_of_offsets = 4
+    offset_count = 4
 
     sequence = new_carr_purcell_sequence(
-        duration=duration, number_of_offsets=number_of_offsets
+        duration=duration, offset_count=offset_count
     )
 
-    _spacing = duration / number_of_offsets
+    _spacing = duration / offset_count
     _offsets = np.array(
         [
             _spacing * 0.5,
@@ -133,7 +133,7 @@ def test_carr_purcell_sequence():
     assert np.allclose(_detuning_rotations, sequence.detuning_rotations)
 
     sequence = new_carr_purcell_sequence(
-        duration=duration, number_of_offsets=number_of_offsets, pre_post_rotation=True,
+        duration=duration, offset_count=offset_count, pre_post_rotation=True,
     )
 
     _offsets = np.array(
@@ -162,13 +162,13 @@ def test_cpmg_sequence():
     """
 
     duration = 10.0
-    number_of_offsets = 4
+    offset_count = 4
 
     sequence = new_cpmg_sequence(
-        duration=duration, number_of_offsets=number_of_offsets,
+        duration=duration, offset_count=offset_count,
     )
 
-    _spacing = duration / number_of_offsets
+    _spacing = duration / offset_count
     _offsets = np.array(
         [
             _spacing * 0.5,
@@ -187,7 +187,7 @@ def test_cpmg_sequence():
     assert np.allclose(_detuning_rotations, sequence.detuning_rotations)
 
     sequence = new_cpmg_sequence(
-        duration=duration, number_of_offsets=number_of_offsets, pre_post_rotation=True,
+        duration=duration, offset_count=offset_count, pre_post_rotation=True,
     )
 
     _offsets = np.array(
@@ -216,16 +216,16 @@ def test_uhrig_sequence():
     """
 
     duration = 10.0
-    number_of_offsets = 4
+    offset_count = 4
 
     sequence = new_uhrig_sequence(
-        duration=duration, number_of_offsets=number_of_offsets
+        duration=duration, offset_count=offset_count
     )
 
-    constant = 0.5 / (number_of_offsets + 1)
+    constant = 0.5 / (offset_count + 1)
     _delta_positions = [
         duration * (np.sin(np.pi * (k + 1) * constant)) ** 2
-        for k in range(number_of_offsets)
+        for k in range(offset_count)
     ]
 
     _offsets = np.array(_delta_positions)
@@ -239,7 +239,7 @@ def test_uhrig_sequence():
     assert np.allclose(_detuning_rotations, sequence.detuning_rotations)
 
     sequence = new_uhrig_sequence(
-        duration=duration, number_of_offsets=number_of_offsets, pre_post_rotation=True,
+        duration=duration, offset_count=offset_count, pre_post_rotation=True,
     )
 
     _offsets = np.array(_delta_positions)
@@ -263,16 +263,16 @@ def test_periodic_sequence():
     """
 
     duration = 10.0
-    number_of_offsets = 4
+    offset_count = 4
 
     sequence = new_periodic_sequence(
-        duration=duration, number_of_offsets=number_of_offsets,
+        duration=duration, offset_count=offset_count,
     )
 
-    constant = 1 / (number_of_offsets + 1)
+    constant = 1 / (offset_count + 1)
     # prepare the offsets for delta comb
     _delta_positions = [
-        duration * k * constant for k in range(1, number_of_offsets + 1)
+        duration * k * constant for k in range(1, offset_count + 1)
     ]
     _offsets = np.array(_delta_positions)
     _rabi_rotations = np.array([np.pi, np.pi, np.pi, np.pi])
@@ -285,7 +285,7 @@ def test_periodic_sequence():
     assert np.allclose(_detuning_rotations, sequence.detuning_rotations)
 
     sequence = new_periodic_sequence(
-        duration=duration, number_of_offsets=number_of_offsets, pre_post_rotation=True,
+        duration=duration, offset_count=offset_count, pre_post_rotation=True,
     )
 
     _offsets = np.array(_delta_positions)
@@ -364,46 +364,46 @@ def test_quadratic_sequence():
     """
 
     duration = 10.0
-    number_inner_offsets = 4
-    number_outer_offsets = 4
+    inner_offset_count = 4
+    outer_offset_count = 4
 
     sequence = new_quadratic_sequence(
         duration=duration,
-        number_inner_offsets=number_inner_offsets,
-        number_outer_offsets=number_outer_offsets,
+        inner_offset_count=inner_offset_count,
+        outer_offset_count=outer_offset_count,
     )
 
-    _offsets = np.zeros((number_outer_offsets + 1, number_inner_offsets + 1))
+    _offsets = np.zeros((outer_offset_count + 1, inner_offset_count + 1))
 
-    constant = 0.5 / (number_outer_offsets + 1)
+    constant = 0.5 / (outer_offset_count + 1)
     _delta_positions = [
         duration * (np.sin(np.pi * (k + 1) * constant)) ** 2
-        for k in range(number_outer_offsets)
+        for k in range(outer_offset_count)
     ]
 
     _outer_offsets = np.array(_delta_positions)
-    _offsets[0:number_outer_offsets, -1] = _outer_offsets
+    _offsets[0:outer_offset_count, -1] = _outer_offsets
 
     _outer_offsets = np.insert(
         _outer_offsets, [0, _outer_offsets.shape[0]], [0, duration],
     )
     _inner_durations = _outer_offsets[1:] - _outer_offsets[0:-1]
 
-    constant = 0.5 / (number_inner_offsets + 1)
+    constant = 0.5 / (inner_offset_count + 1)
     _delta_positions = [
-        (np.sin(np.pi * (k + 1) * constant)) ** 2 for k in range(number_inner_offsets)
+        (np.sin(np.pi * (k + 1) * constant)) ** 2 for k in range(inner_offset_count)
     ]
     _delta_positions = np.array(_delta_positions)
     for inner_sequence_idx in range(_inner_durations.shape[0]):
         _inner_deltas = _inner_durations[inner_sequence_idx] * _delta_positions
         _inner_deltas = _outer_offsets[inner_sequence_idx] + _inner_deltas
-        _offsets[inner_sequence_idx, 0:number_inner_offsets] = _inner_deltas
+        _offsets[inner_sequence_idx, 0:inner_offset_count] = _inner_deltas
 
     _rabi_rotations = np.zeros(_offsets.shape)
     _detuning_rotations = np.zeros(_offsets.shape)
 
-    _rabi_rotations[0:number_outer_offsets, -1] = np.pi
-    _detuning_rotations[0 : (number_outer_offsets + 1), 0:number_inner_offsets] = np.pi
+    _rabi_rotations[0:outer_offset_count, -1] = np.pi
+    _detuning_rotations[0 : (outer_offset_count + 1), 0:inner_offset_count] = np.pi
 
     _offsets = np.reshape(_offsets, (-1,))
     _rabi_rotations = np.reshape(_rabi_rotations, (-1,))
@@ -422,8 +422,8 @@ def test_quadratic_sequence():
 
     sequence = new_quadratic_sequence(
         duration=duration,
-        number_inner_offsets=number_inner_offsets,
-        number_outer_offsets=number_outer_offsets,
+        inner_offset_count=inner_offset_count,
+        outer_offset_count=outer_offset_count,
         pre_post_rotation=True,
     )
 
@@ -648,7 +648,7 @@ def test_if_carr_purcell_sequence_with_odd_pulses_is_identity():
     pi/2-pulses is an identity, when the number of pulses is odd.
     """
     odd_carr_purcell_sequence = new_carr_purcell_sequence(
-        duration=10.0, number_of_offsets=7, pre_post_rotation=True
+        duration=10.0, offset_count=7, pre_post_rotation=True
     )
 
     assert _pulses_produce_identity(odd_carr_purcell_sequence)
@@ -660,7 +660,7 @@ def test_if_carr_purcell_sequence_with_even_pulses_is_identity():
     pi/2-pulses is an identity, when the number of pulses is even.
     """
     even_carr_purcell_sequence = new_carr_purcell_sequence(
-        duration=10.0, number_of_offsets=8, pre_post_rotation=True
+        duration=10.0, offset_count=8, pre_post_rotation=True
     )
 
     assert _pulses_produce_identity(even_carr_purcell_sequence)
@@ -672,7 +672,7 @@ def test_if_cpmg_sequence_with_odd_pulses_is_identity():
     pi/2-pulses and an extra Z rotation is an identity, when the number of pulses is odd.
     """
     odd_cpmg_sequence = new_cpmg_sequence(
-        duration=10.0, number_of_offsets=7, pre_post_rotation=True,
+        duration=10.0, offset_count=7, pre_post_rotation=True,
     )
 
     assert _pulses_produce_identity(odd_cpmg_sequence)
@@ -684,7 +684,7 @@ def test_if_cpmg_sequence_with_even_pulses_is_identity():
     pi/2-pulses is an identity, when the number of pulses is even.
     """
     even_cpmg_sequence = new_cpmg_sequence(
-        duration=10.0, number_of_offsets=8, pre_post_rotation=True,
+        duration=10.0, offset_count=8, pre_post_rotation=True,
     )
 
     assert _pulses_produce_identity(even_cpmg_sequence)
@@ -696,7 +696,7 @@ def test_if_uhrig_sequence_with_odd_pulses_is_identity():
     pi/2-pulses and an extra Z rotation is an identity, when the number of pulses is odd.
     """
     odd_uhrig_sequence = new_uhrig_sequence(
-        duration=10.0, number_of_offsets=7, pre_post_rotation=True,
+        duration=10.0, offset_count=7, pre_post_rotation=True,
     )
 
     assert _pulses_produce_identity(odd_uhrig_sequence)
@@ -708,7 +708,7 @@ def test_if_uhrig_sequence_with_even_pulses_is_identity():
     pi/2-pulses is an identity, when the number of pulses is even.
     """
     even_uhrig_sequence = new_uhrig_sequence(
-        duration=10.0, number_of_offsets=8, pre_post_rotation=True,
+        duration=10.0, offset_count=8, pre_post_rotation=True,
     )
 
     assert _pulses_produce_identity(even_uhrig_sequence)
@@ -720,7 +720,7 @@ def test_if_periodic_sequence_with_odd_pulses_is_identity():
     pi/2-pulses is an identity, when the number of pulses is odd.
     """
     odd_periodic_sequence = new_periodic_sequence(
-        duration=10.0, number_of_offsets=7, pre_post_rotation=True,
+        duration=10.0, offset_count=7, pre_post_rotation=True,
     )
 
     assert _pulses_produce_identity(odd_periodic_sequence)
@@ -732,7 +732,7 @@ def test_if_periodic_sequence_with_even_pulses_is_identity():
     pi/2-pulses is an identity, when the number of pulses is even.
     """
     even_periodic_sequence = new_periodic_sequence(
-        duration=10.0, number_of_offsets=8, pre_post_rotation=True,
+        duration=10.0, offset_count=8, pre_post_rotation=True,
     )
 
     assert _pulses_produce_identity(even_periodic_sequence)
@@ -777,8 +777,8 @@ def test_if_quadratic_sequence_with_odd_pulses_is_identity():
     """
     odd_quadratic_sequence = new_quadratic_sequence(
         duration=10.0,
-        number_inner_offsets=7,
-        number_outer_offsets=7,
+        inner_offset_count=7,
+        outer_offset_count=7,
         pre_post_rotation=True,
     )
 
@@ -796,8 +796,8 @@ def test_if_quadratic_sequence_with_even_pulses_is_identity():
     """
     even_quadratic_sequence = new_quadratic_sequence(
         duration=10.0,
-        number_inner_offsets=8,
-        number_outer_offsets=8,
+        inner_offset_count=8,
+        outer_offset_count=8,
         pre_post_rotation=True,
     )
 
@@ -816,8 +816,8 @@ def test_if_quadratic_sequence_with_odd_inner_pulses_is_identity():
     """
     inner_odd_quadratic_sequence = new_quadratic_sequence(
         duration=10.0,
-        number_inner_offsets=7,
-        number_outer_offsets=8,
+        inner_offset_count=7,
+        outer_offset_count=8,
         pre_post_rotation=True,
     )
 
@@ -835,8 +835,8 @@ def test_if_quadratic_sequence_with_even_inner_pulses_is_identity():
     """
     inner_even_quadratic_sequence = new_quadratic_sequence(
         duration=10.0,
-        number_inner_offsets=8,
-        number_outer_offsets=7,
+        inner_offset_count=8,
+        outer_offset_count=7,
         pre_post_rotation=True,
     )
 

--- a/tests/test_predefined_dynamical_decoupling.py
+++ b/tests/test_predefined_dynamical_decoupling.py
@@ -110,9 +110,7 @@ def test_carr_purcell_sequence():
     duration = 10.0
     offset_count = 4
 
-    sequence = new_carr_purcell_sequence(
-        duration=duration, offset_count=offset_count
-    )
+    sequence = new_carr_purcell_sequence(duration=duration, offset_count=offset_count)
 
     _spacing = duration / offset_count
     _offsets = np.array(
@@ -164,9 +162,7 @@ def test_cpmg_sequence():
     duration = 10.0
     offset_count = 4
 
-    sequence = new_cpmg_sequence(
-        duration=duration, offset_count=offset_count,
-    )
+    sequence = new_cpmg_sequence(duration=duration, offset_count=offset_count,)
 
     _spacing = duration / offset_count
     _offsets = np.array(
@@ -218,9 +214,7 @@ def test_uhrig_sequence():
     duration = 10.0
     offset_count = 4
 
-    sequence = new_uhrig_sequence(
-        duration=duration, offset_count=offset_count
-    )
+    sequence = new_uhrig_sequence(duration=duration, offset_count=offset_count)
 
     constant = 0.5 / (offset_count + 1)
     _delta_positions = [
@@ -265,15 +259,11 @@ def test_periodic_sequence():
     duration = 10.0
     offset_count = 4
 
-    sequence = new_periodic_sequence(
-        duration=duration, offset_count=offset_count,
-    )
+    sequence = new_periodic_sequence(duration=duration, offset_count=offset_count,)
 
     constant = 1 / (offset_count + 1)
     # prepare the offsets for delta comb
-    _delta_positions = [
-        duration * k * constant for k in range(1, offset_count + 1)
-    ]
+    _delta_positions = [duration * k * constant for k in range(1, offset_count + 1)]
     _offsets = np.array(_delta_positions)
     _rabi_rotations = np.array([np.pi, np.pi, np.pi, np.pi])
     _azimuthal_angles = np.array([0, 0, 0, 0])


### PR DESCRIPTION
`number_of_offsets` -> `offset_count`
`number_inner_offsets` -> `inner_offset_count`
`number_outer_offsets` -> `outer_offset_count`
This is a breaking change. We might do a release later after removing the drive control wrapper function.

Also removed unnecessary default values in private functions.