### PR TITLE
Remove default values in DrivenControl

### DIFF
--- a/qctrlopencontrols/driven_controls/driven_control.py
+++ b/qctrlopencontrols/driven_controls/driven_control.py
@@ -36,29 +36,22 @@ class DrivenControl:
 
     Parameters
     ----------
-    rabi_rates : np.ndarray, optional
+    rabi_rates : np.ndarray
         The Rabi rates :math:`\{\Omega_n\}` for each segment, in units of radians per second. Every
         element must be non-negative. Represented as a 1D array of length :math:`N`, where :math:`N`
-        is number of segments. You can omit this field if the Rabi rate is zero on all segments.
-    azimuthal_angles : np.ndarray, optional
+        is number of segments.
+    azimuthal_angles : np.ndarray
         The azimuthal angles :math:`\{\phi_n\}` for each segment. Represented as a 1D array of
-        length :math:`N`, where :math:`N` is number of segments. You can omit this field if the
-        azimuthal angle is zero on all segments.
-    detunings : np.ndarray, optional
+        length :math:`N`, where :math:`N` is number of segments.
+    detunings : np.ndarray
         The detunings :math:`\{\Delta_n\}` for each segment, in units of radians per second.
-        Represented as a 1D array of length :math:`N`, where :math:`N` is number of segments. You
-        can omit this field if the detuning is zero on all segments.
-    durations : np.ndarray, optional
+        Represented as a 1D array of length :math:`N`, where :math:`N` is number of segments.
+    durations : np.ndarray
         The durations :math:`\{\delta t_n\}` for each segment, in units of seconds. Every element
         must be positive. Represented as a 1D array of length :math:`N`, where :math:`N` is number
-        of segments. Defaults to an array of ones if omitted.
+        of segments.
     name : string, optional
         An optional string to name the control. Defaults to ``None``.
-
-    Raises
-    ------
-    ArgumentsValueError
-        Raised when an argument is invalid.
 
     Notes
     -----
@@ -109,7 +102,7 @@ class DrivenControl:
         detunings = np.asarray(detunings, dtype=np.float)
         durations = np.asarray(durations, dtype=np.float)
 
-        # check if all non-None inputs have the same length
+        # check if all input parameters have the same length
         parameter_length = {
             len(parameter)
             for parameter in [rabi_rates, azimuthal_angles, detunings, durations]
@@ -609,7 +602,8 @@ class DrivenControl:
         return plot_dictionary
 
     def __str__(self):
-        """Prepares a friendly string format for a Driven Control
+        """
+        Prepares a friendly string format for a Driven Control.
         """
         driven_control_string = list()
 

--- a/qctrlopencontrols/driven_controls/driven_control.py
+++ b/qctrlopencontrols/driven_controls/driven_control.py
@@ -32,7 +32,7 @@ from ..utils import (
 
 class DrivenControl:
     r"""
-A piecewise-constant driven control for a single qubit.
+    A piecewise-constant driven control for a single qubit.
 
     Parameters
     ----------
@@ -168,7 +168,7 @@ A piecewise-constant driven control for a single qubit.
     @property
     def maximum_rabi_rate(self) -> float:
         r"""
-Returns the maximum Rabi rate of the control.
+        Returns the maximum Rabi rate of the control.
 
         Returns
         -------
@@ -181,7 +181,7 @@ Returns the maximum Rabi rate of the control.
     @property
     def maximum_detuning(self) -> float:
         r"""
-Returns the maximum detuning of the control.
+        Returns the maximum detuning of the control.
 
         Returns
         -------
@@ -193,7 +193,7 @@ Returns the maximum detuning of the control.
     @property
     def amplitude_x(self) -> np.ndarray:
         r"""
-Returns the x-amplitude.
+        Returns the x-amplitude.
 
         Returns
         -------
@@ -206,7 +206,7 @@ Returns the x-amplitude.
     @property
     def amplitude_y(self) -> np.ndarray:
         r"""
-Returns the y-amplitude.
+        Returns the y-amplitude.
 
         Returns
         -------
@@ -219,7 +219,7 @@ Returns the y-amplitude.
     @property
     def angles(self) -> np.ndarray:
         r"""
-Returns the Bloch sphere rotation angles.
+        Returns the Bloch sphere rotation angles.
 
         Returns
         -------
@@ -238,7 +238,7 @@ Returns the Bloch sphere rotation angles.
     @property
     def directions(self) -> np.ndarray:
         r"""
-Returns the Bloch sphere rotation directions.
+        Returns the Bloch sphere rotation directions.
 
         Returns
         -------
@@ -277,7 +277,7 @@ Returns the Bloch sphere rotation directions.
     @property
     def times(self) -> np.ndarray:
         r"""
-Returns the boundary times of the control segments.
+        Returns the boundary times of the control segments.
 
         Returns
         ------
@@ -291,7 +291,7 @@ Returns the boundary times of the control segments.
     @property
     def maximum_duration(self) -> float:
         r"""
-Returns the duration of the longest control segment.
+        Returns the duration of the longest control segment.
 
         Returns
         -------
@@ -304,7 +304,7 @@ Returns the duration of the longest control segment.
     @property
     def minimum_duration(self) -> float:
         r"""
-Returns the duration of the shortest control segment.
+        Returns the duration of the shortest control segment.
 
         Returns
         -------
@@ -317,7 +317,7 @@ Returns the duration of the shortest control segment.
     @property
     def duration(self) -> float:
         r"""
-Returns the total duration of the control.
+        Returns the total duration of the control.
 
         Returns
         -------

--- a/qctrlopencontrols/driven_controls/driven_control.py
+++ b/qctrlopencontrols/driven_controls/driven_control.py
@@ -95,33 +95,30 @@ class DrivenControl:
 
     def __init__(
         self,
-        rabi_rates: Optional[np.ndarray] = None,
-        azimuthal_angles: Optional[np.ndarray] = None,
-        detunings: Optional[np.ndarray] = None,
-        durations: Optional[np.ndarray] = None,
+        rabi_rates: np.ndarray,
+        azimuthal_angles: np.ndarray,
+        detunings: np.ndarray,
+        durations: np.ndarray,
         name: Optional[str] = None,
     ):
 
         self.name = name
 
-        # set default values if all inputs are ``None``
-        if all(v is None for v in [rabi_rates, azimuthal_angles, detunings, durations]):
-            rabi_rates = np.array([np.pi])
-            azimuthal_angles = np.array([0.0])
-            detunings = np.array([0.0])
-            durations = np.array([1.0])
+        rabi_rates = np.asarray(rabi_rates, dtype=np.float)
+        azimuthal_angles = np.asarray(azimuthal_angles, dtype=np.float)
+        detunings = np.asarray(detunings, dtype=np.float)
+        durations = np.asarray(durations, dtype=np.float)
 
         # check if all non-None inputs have the same length
-        input_lengths = {
-            np.array(v).size
-            for v in [rabi_rates, azimuthal_angles, detunings, durations]
-            if v is not None
+        parameter_length = {
+            len(parameter)
+            for parameter in [rabi_rates, azimuthal_angles, detunings, durations]
         }
 
         check_arguments(
-            len(input_lengths) == 1,
-            "Rabi rates, Azimuthal angles, Detunings and Durations "
-            "must be of same length",
+            len(parameter_length) == 1,
+            "rabi rates, azimuthal angles, detunings and durations "
+            "must be of same length.",
             {
                 "rabi_rates": rabi_rates,
                 "azimuthal_angles": azimuthal_angles,
@@ -129,22 +126,6 @@ class DrivenControl:
                 "durations": durations,
             },
         )
-
-        input_length = input_lengths.pop()
-
-        if rabi_rates is None:
-            rabi_rates = np.zeros(input_length)
-        if azimuthal_angles is None:
-            azimuthal_angles = np.zeros(input_length)
-        if detunings is None:
-            detunings = np.zeros(input_length)
-        if durations is None:
-            durations = np.ones(input_length)
-
-        rabi_rates = np.array(rabi_rates, dtype=np.float).flatten()
-        azimuthal_angles = np.array(azimuthal_angles, dtype=np.float).flatten()
-        detunings = np.array(detunings, dtype=np.float).flatten()
-        durations = np.array(durations, dtype=np.float).flatten()
 
         # check if all the rabi_rates are greater than zero
         check_arguments(

--- a/qctrlopencontrols/driven_controls/predefined.py
+++ b/qctrlopencontrols/driven_controls/predefined.py
@@ -1122,5 +1122,6 @@ def new_modulated_gaussian_control(
     return DrivenControl(
         rabi_rates=np.abs(modulated_gaussian_segments),
         azimuthal_angles=azimuthal_angles,
+        detunings=np.zeros(segment_count),
         durations=np.array([segment_duration] * segment_count),
     )

--- a/tests/test_driven_controls.py
+++ b/tests/test_driven_controls.py
@@ -61,78 +61,7 @@ def test_driven_controls():
     assert np.allclose(driven_control.durations, _durations)
     assert np.allclose(driven_control.detunings, _detunings)
     assert np.allclose(driven_control.azimuthal_angles, _azimuthal_angles)
-
     assert driven_control.name == _name
-
-    driven_control = DrivenControl(
-        rabi_rates=None,
-        azimuthal_angles=_azimuthal_angles,
-        detunings=_detunings,
-        durations=_durations,
-        name=_name,
-    )
-
-    assert np.allclose(driven_control.rabi_rates, np.array([0.0, 0.0, 0.0]))
-    assert np.allclose(driven_control.durations, _durations)
-    assert np.allclose(driven_control.detunings, _detunings)
-    assert np.allclose(driven_control.azimuthal_angles, _azimuthal_angles)
-
-    driven_control = DrivenControl(
-        rabi_rates=_rabi_rates,
-        azimuthal_angles=None,
-        detunings=_detunings,
-        durations=_durations,
-        name=_name,
-    )
-
-    assert np.allclose(driven_control.rabi_rates, _rabi_rates)
-    assert np.allclose(driven_control.durations, _durations)
-    assert np.allclose(driven_control.detunings, _detunings)
-    assert np.allclose(driven_control.azimuthal_angles, np.array([0.0, 0.0, 0.0]))
-
-    driven_control = DrivenControl(
-        rabi_rates=_rabi_rates,
-        azimuthal_angles=_azimuthal_angles,
-        detunings=None,
-        durations=_durations,
-        name=_name,
-    )
-
-    assert np.allclose(driven_control.rabi_rates, _rabi_rates)
-    assert np.allclose(driven_control.durations, _durations)
-    assert np.allclose(driven_control.detunings, np.array([0.0, 0.0, 0.0]))
-    assert np.allclose(driven_control.azimuthal_angles, _azimuthal_angles)
-
-    driven_control = DrivenControl(
-        rabi_rates=_rabi_rates,
-        azimuthal_angles=_azimuthal_angles,
-        detunings=_detunings,
-        durations=None,
-        name=_name,
-    )
-
-    assert np.allclose(driven_control.rabi_rates, _rabi_rates)
-    assert np.allclose(driven_control.durations, np.array([1.0, 1.0, 1.0]))
-    assert np.allclose(driven_control.detunings, _detunings)
-    assert np.allclose(driven_control.azimuthal_angles, _azimuthal_angles)
-
-    driven_control = DrivenControl()
-    assert np.allclose(driven_control.rabi_rates, np.array([np.pi]))
-    assert np.allclose(driven_control.durations, np.array([1.0]))
-    assert np.allclose(driven_control.detunings, np.array([0.0]))
-    assert np.allclose(driven_control.azimuthal_angles, np.array([0.0]))
-
-    with pytest.raises(ArgumentsValueError):
-        _ = DrivenControl(rabi_rates=[-1])
-        _ = DrivenControl(detunings=[-1])
-        _ = DrivenControl(durations=[0])
-        _ = DrivenControl()
-        _ = DrivenControl(
-            rabi_rates=[1, 2],
-            azimuthal_angles=[1, 2, 3],
-            detunings=None,
-            durations=None,
-        )
 
 
 def test_control_directions():

--- a/tests/test_driven_controls.py
+++ b/tests/test_driven_controls.py
@@ -20,8 +20,10 @@ Tests for driven controls.
 import os
 
 import numpy as np
+import pytest
 
 from qctrlopencontrols import DrivenControl
+from qctrlopencontrols.exceptions import ArgumentsValueError
 
 
 def _remove_file(filename):
@@ -60,6 +62,72 @@ def test_driven_controls():
     assert np.allclose(driven_control.detunings, _detunings)
     assert np.allclose(driven_control.azimuthal_angles, _azimuthal_angles)
     assert driven_control.name == _name
+
+
+def test_driven_control_default_values():
+    """
+    Tests driven control with default values and invalid input.
+    """
+    _rabi_rates = [np.pi, np.pi, 0]
+    _azimuthal_angles = [np.pi / 2, 0, -np.pi]
+    _detunings = [0, 0, 0]
+    _durations = [1, 2, 3]
+
+    _name = "driven_control"
+
+    driven_control = DrivenControl(
+        rabi_rates=None,
+        azimuthal_angles=_azimuthal_angles,
+        detunings=_detunings,
+        durations=_durations,
+        name=_name,
+    )
+
+    assert np.allclose(driven_control.rabi_rates, np.array([0.0, 0.0, 0.0]))
+    assert np.allclose(driven_control.durations, _durations)
+    assert np.allclose(driven_control.detunings, _detunings)
+    assert np.allclose(driven_control.azimuthal_angles, _azimuthal_angles)
+
+    driven_control = DrivenControl(
+        rabi_rates=_rabi_rates,
+        azimuthal_angles=None,
+        detunings=_detunings,
+        durations=_durations,
+        name=_name,
+    )
+
+    assert np.allclose(driven_control.rabi_rates, _rabi_rates)
+    assert np.allclose(driven_control.durations, _durations)
+    assert np.allclose(driven_control.detunings, _detunings)
+    assert np.allclose(driven_control.azimuthal_angles, np.array([0.0, 0.0, 0.0]))
+
+    driven_control = DrivenControl(
+        rabi_rates=_rabi_rates,
+        azimuthal_angles=_azimuthal_angles,
+        detunings=None,
+        durations=_durations,
+        name=_name,
+    )
+
+    assert np.allclose(driven_control.rabi_rates, _rabi_rates)
+    assert np.allclose(driven_control.durations, _durations)
+    assert np.allclose(driven_control.detunings, np.array([0.0, 0.0, 0.0]))
+    assert np.allclose(driven_control.azimuthal_angles, _azimuthal_angles)
+
+    driven_control = DrivenControl(durations=[1])
+    assert np.allclose(driven_control.rabi_rates, np.array([0.0]))
+    assert np.allclose(driven_control.durations, np.array([1.0]))
+    assert np.allclose(driven_control.detunings, np.array([0.0]))
+    assert np.allclose(driven_control.azimuthal_angles, np.array([0.0]))
+
+    with pytest.raises(ArgumentsValueError):
+        _ = DrivenControl(durations=[1], rabi_rates=[-1])
+
+    with pytest.raises(ArgumentsValueError):
+        _ = DrivenControl(durations=[0])
+
+    with pytest.raises(ArgumentsValueError):
+        _ = DrivenControl(durations=[1], rabi_rates=[1, 2], azimuthal_angles=[1, 2, 3],)
 
 
 def test_control_directions():

--- a/tests/test_driven_controls.py
+++ b/tests/test_driven_controls.py
@@ -20,10 +20,8 @@ Tests for driven controls.
 import os
 
 import numpy as np
-import pytest
 
 from qctrlopencontrols import DrivenControl
-from qctrlopencontrols.exceptions import ArgumentsValueError
 
 
 def _remove_file(filename):


### PR DESCRIPTION
- remove unnecessary default values in `DrivenControl`
- modify tests depending on the default values
- add `detunings` to `new_modulated_gaussian_control` as defaults values  are now removed.
