### PR TITLE
misc: Fix type issue in tests

### DIFF
--- a/tests/test_driven_controls.py
+++ b/tests/test_driven_controls.py
@@ -298,18 +298,16 @@ def test_pretty_print():
         durations=_durations,
     )
 
-    _pretty_rabi_rates = [
-        str(_rabi_rate / _maximum_rabi_rate) for _rabi_rate in _rabi_rates
-    ]
-    _pretty_azimuthal_angles = [
-        str(azimuthal_angle / np.pi) for azimuthal_angle in _azimuthal_angles
-    ]
-    _pretty_detunings = [str(detuning / _maximum_detuning) for detuning in _detunings]
-    _pretty_durations = [str(duration / 3.0) for duration in _durations]
-    _pretty_rabi_rates = ",".join(_pretty_rabi_rates)
-    _pretty_azimuthal_angles = ",".join(_pretty_azimuthal_angles)
-    _pretty_detunings = ",".join(_pretty_detunings)
-    _pretty_durations = ",".join(_pretty_durations)
+    _pretty_rabi_rates = ",".join(
+        [str(_rabi_rate / _maximum_rabi_rate) for _rabi_rate in _rabi_rates]
+    )
+    _pretty_azimuthal_angles = ",".join(
+        [str(azimuthal_angle / np.pi) for azimuthal_angle in _azimuthal_angles]
+    )
+    _pretty_detunings = ",".join(
+        [str(detuning / _maximum_detuning) for detuning in _detunings]
+    )
+    _pretty_durations = ",".join([str(duration / 3.0) for duration in _durations])
 
     _pretty_string = []
     _pretty_string.append(
@@ -323,9 +321,9 @@ def test_pretty_print():
     )
     _pretty_string.append("Durations = [{}] x 3.0".format(_pretty_durations))
 
-    _pretty_string = "\n".join(_pretty_string)
+    expected_string = "\n".join(_pretty_string)
 
-    assert str(driven_control) == _pretty_string
+    assert str(driven_control) == expected_string
 
     _maximum_rabi_rate = 0.0
     _maximum_detuning = 1.0
@@ -341,16 +339,14 @@ def test_pretty_print():
         durations=_durations,
     )
 
-    _pretty_rabi_rates = ["0", "0", "0"]
-    _pretty_azimuthal_angles = [
-        str(azimuthal_angle / np.pi) for azimuthal_angle in _azimuthal_angles
-    ]
-    _pretty_detunings = [str(detuning / _maximum_detuning) for detuning in _detunings]
-    _pretty_durations = [str(duration / 3.0) for duration in _durations]
-    _pretty_rabi_rates = ",".join(_pretty_rabi_rates)
-    _pretty_azimuthal_angles = ",".join(_pretty_azimuthal_angles)
-    _pretty_detunings = ",".join(_pretty_detunings)
-    _pretty_durations = ",".join(_pretty_durations)
+    _pretty_rabi_rates = ",".join(["0", "0", "0"])
+    _pretty_azimuthal_angles = ",".join(
+        [str(azimuthal_angle / np.pi) for azimuthal_angle in _azimuthal_angles]
+    )
+    _pretty_detunings = ",".join(
+        [str(detuning / _maximum_detuning) for detuning in _detunings]
+    )
+    _pretty_durations = ",".join([str(duration / 3.0) for duration in _durations])
 
     _pretty_string = []
     _pretty_string.append(
@@ -364,15 +360,15 @@ def test_pretty_print():
     )
     _pretty_string.append("Durations = [{}] x 3.0".format(_pretty_durations))
 
-    _pretty_string = "\n".join(_pretty_string)
+    expected_string = "\n".join(_pretty_string)
 
-    assert str(driven_control) == _pretty_string
+    assert str(driven_control) == expected_string
 
     _maximum_rabi_rate = 2 * np.pi
     _maximum_detuning = 0.0
     _rabi_rates = [np.pi, 2 * np.pi, np.pi]
     _azimuthal_angles = [0, np.pi / 2, -np.pi / 2]
-    _detunings = [0, 0.0, 0]
+    _detunings = [0, 0, 0]
     _durations = [1.0, 1.0, 1.0]
 
     driven_control = DrivenControl(
@@ -382,18 +378,14 @@ def test_pretty_print():
         durations=_durations,
     )
 
-    _pretty_rabi_rates = [
-        str(_rabi_rate / _maximum_rabi_rate) for _rabi_rate in _rabi_rates
-    ]
-    _pretty_azimuthal_angles = [
-        str(azimuthal_angle / np.pi) for azimuthal_angle in _azimuthal_angles
-    ]
-    _pretty_detunings = ["0", "0", "0"]
-    _pretty_durations = [str(duration / 3.0) for duration in _durations]
-    _pretty_rabi_rates = ",".join(_pretty_rabi_rates)
-    _pretty_azimuthal_angles = ",".join(_pretty_azimuthal_angles)
-    _pretty_detunings = ",".join(_pretty_detunings)
-    _pretty_durations = ",".join(_pretty_durations)
+    _pretty_rabi_rates = ",".join(
+        [str(_rabi_rate / _maximum_rabi_rate) for _rabi_rate in _rabi_rates]
+    )
+    _pretty_azimuthal_angles = ",".join(
+        [str(azimuthal_angle / np.pi) for azimuthal_angle in _azimuthal_angles]
+    )
+    _pretty_detunings = ",".join(["0", "0", "0"])
+    _pretty_durations = ",".join([str(duration / 3.0) for duration in _durations])
 
     _pretty_string = []
     _pretty_string.append(
@@ -407,6 +399,6 @@ def test_pretty_print():
     )
     _pretty_string.append("Durations = [{}] x 3.0".format(_pretty_durations))
 
-    _pretty_string = "\n".join(_pretty_string)
+    expected_string = "\n".join(_pretty_string)
 
-    assert str(driven_control) == _pretty_string
+    assert str(driven_control) == expected_string

--- a/tests/test_dynamical_decoupling.py
+++ b/tests/test_dynamical_decoupling.py
@@ -242,9 +242,9 @@ def test_pretty_string_format():
         )
     )
 
-    _pretty_string = "\n".join(_pretty_string)
+    expected_string = "\n".join(_pretty_string)
 
-    assert _pretty_string == str(dd_sequence)
+    assert expected_string == str(dd_sequence)
 
     dd_sequence = DynamicDecouplingSequence(
         duration=_duration,
@@ -282,9 +282,9 @@ def test_pretty_string_format():
             _detuning_rotations[2] / np.pi,
         )
     )
-    _pretty_string = "\n".join(_pretty_string)
+    expected_string = "\n".join(_pretty_string)
 
-    assert _pretty_string == str(dd_sequence)
+    assert expected_string == str(dd_sequence)
 
 
 def test_conversion_to_driven_controls():
@@ -779,17 +779,13 @@ def test_free_evolution_conversion():
     """
     _duration = 10.0
     _name = "test_sequence"
-    _offsets = []
-    _rabi_rotations = []
-    _azimuthal_angles = []
-    _detuning_rotations = []
 
     dd_sequence = DynamicDecouplingSequence(
         duration=_duration,
-        offsets=_offsets,
-        rabi_rotations=_rabi_rotations,
-        azimuthal_angles=_azimuthal_angles,
-        detuning_rotations=_detuning_rotations,
+        offsets=[],
+        rabi_rotations=[],
+        azimuthal_angles=[],
+        detuning_rotations=[],
         name=_name,
     )
 

--- a/tests/test_predefined_dynamical_decoupling.py
+++ b/tests/test_predefined_dynamical_decoupling.py
@@ -313,13 +313,14 @@ def test_walsh_sequence():
             ** binary_order[hamming_weight - 1 - i]
         )
 
-    walsh_relative_offsets = []
-    for i in range(samples - 1):
-        if walsh_array[i] != walsh_array[i + 1]:
-            walsh_relative_offsets.append((i + 1) * (1.0 / samples))
-    walsh_relative_offsets = np.array(walsh_relative_offsets, dtype=np.float)
+    walsh_relative_offsets = np.array(
+        [
+            (i + 1) * (1.0 / samples)
+            for i in range(samples - 1)
+            if walsh_array[i] != walsh_array[i + 1]
+        ]
+    )
     _offsets = duration * walsh_relative_offsets
-    _offsets = np.array(_offsets)
 
     _rabi_rotations = np.pi * np.ones(_offsets.shape)
     _azimuthal_angles = np.zeros(_offsets.shape)
@@ -446,8 +447,9 @@ def test_x_concatenated_sequence():
     )
 
     _spacing = duration / (2 ** concatenation_order)
-    _offsets = [_spacing, 3 * _spacing, 4 * _spacing, 5 * _spacing, 7 * _spacing]
-    _offsets = np.array(_offsets)
+    _offsets = np.array(
+        [_spacing, 3 * _spacing, 4 * _spacing, 5 * _spacing, 7 * _spacing]
+    )
     _rabi_rotations = np.pi * np.ones(_offsets.shape)
 
     _azimuthal_angles = np.zeros(_offsets.shape)
@@ -490,59 +492,46 @@ def test_xy_concatenated_sequence():
     )
 
     _spacing = duration / (2 ** (concatenation_order * 2))
-    _offsets = [
-        _spacing,
-        2 * _spacing,
-        3 * _spacing,
-        4 * _spacing,
-        5 * _spacing,
-        6 * _spacing,
-        7 * _spacing,
-        9 * _spacing,
-        10 * _spacing,
-        11 * _spacing,
-        12 * _spacing,
-        13 * _spacing,
-        14 * _spacing,
-        15 * _spacing,
-    ]
-    _offsets = np.array(_offsets)
-    _rabi_rotations = [
-        np.pi,
-        np.pi,
-        np.pi,
-        0.0,
-        np.pi,
-        np.pi,
-        np.pi,
-        np.pi,
-        np.pi,
-        np.pi,
-        0,
-        np.pi,
-        np.pi,
-        np.pi,
-    ]
-    _rabi_rotations = np.array(_rabi_rotations)
-    _azimuthal_angles = [
-        0,
-        np.pi / 2,
-        0,
-        0,
-        0,
-        np.pi / 2,
-        0,
-        0,
-        np.pi / 2,
-        0,
-        0,
-        0,
-        np.pi / 2,
-        0,
-    ]
-    _azimuthal_angles = np.array(_azimuthal_angles)
-    _detuning_rotations = [0, 0, 0, np.pi, 0, 0, 0, 0, 0, 0, np.pi, 0, 0, 0]
-    _detuning_rotations = np.array(_detuning_rotations)
+    _offsets = np.array(
+        [
+            _spacing,
+            2 * _spacing,
+            3 * _spacing,
+            4 * _spacing,
+            5 * _spacing,
+            6 * _spacing,
+            7 * _spacing,
+            9 * _spacing,
+            10 * _spacing,
+            11 * _spacing,
+            12 * _spacing,
+            13 * _spacing,
+            14 * _spacing,
+            15 * _spacing,
+        ]
+    )
+    _rabi_rotations = np.array(
+        [
+            np.pi,
+            np.pi,
+            np.pi,
+            0.0,
+            np.pi,
+            np.pi,
+            np.pi,
+            np.pi,
+            np.pi,
+            np.pi,
+            0,
+            np.pi,
+            np.pi,
+            np.pi,
+        ]
+    )
+    _azimuthal_angles = np.array(
+        [0, np.pi / 2, 0, 0, 0, np.pi / 2, 0, 0, np.pi / 2, 0, 0, 0, np.pi / 2, 0,]
+    )
+    _detuning_rotations = np.array([0, 0, 0, np.pi, 0, 0, 0, 0, 0, 0, np.pi, 0, 0, 0])
 
     assert np.allclose(_offsets, sequence.offsets)
     assert np.allclose(_rabi_rotations, sequence.rabi_rotations)


### PR DESCRIPTION
In preparing of enabling the `check_untyped_defs` option, we first fix the type in issue in the test.

The type issues are mainly due to the casting among List, string, and numpy.ndarray.