### PR TITLE
fix: Remove auto-generated docs files with make clean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,8 +66,6 @@ instance/
 
 # Sphinx documentation
 docs/_build/
-docs/qctrlopencontrols/
-docs/qctrlopencontrols.rst
 
 # PyBuilder
 target/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -14,6 +14,12 @@ help:
 
 .PHONY: help Makefile
 
+# Custom clean target that also removes autosummary generated files. Can
+# be removed when https://github.com/sphinx-doc/sphinx/issues/1999 is fixed.
+clean:
+	@rm -rf qctrlopencontrols.rst qctrlopencontrols/
+	@$(SPHINXBUILD)  -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qctrl-open-controls"
-version = "7.0.0"
+version = "7.0.1"
 description = "Q-CTRL Open Controls"
 license = "Apache-2.0"
 authors = ["Q-CTRL <support@q-ctrl.com>"]

--- a/qctrlopencontrols/__init__.py
+++ b/qctrlopencontrols/__init__.py
@@ -16,7 +16,7 @@
 Top-level package for Q-CTRL Open Controls.
 """
 
-__version__ = "7.0.0"
+__version__ = "7.0.1"
 
 from .driven_controls.driven_control import DrivenControl
 from .driven_controls.predefined import (

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ if os.path.exists(readme_path):
 setup(
     long_description=readme,
     name='qctrl-open-controls',
-    version='7.0.0',
+    version='7.0.1',
     description='Q-CTRL Open Controls',
     python_requires='<3.9,>=3.6.4',
     project_urls={"repository": "https://github.com/qctrl/python-open-controls"},


### PR DESCRIPTION
This is necessary due to a sphinx bug
(https://github.com/sphinx-doc/sphinx/issues/1999), but until
that's fixed we might as well have a `make clean` implementation
that actually cleans.
