### PR TITLE
fix: Fix project name in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Q-CTRL Open Controls
+# Q-CTRL Python Open Controls
 
 Q-CTRL Open Controls is an open-source Python package that makes it easy to
 create and deploy established error-robust quantum control protocols from the


### PR DESCRIPTION
The naming conventions in Elements (https://elements.q-ctrl.com/code/naming-conventions/#projects) say that:
1. The project name is what you see as the main heading in the README file of the repository.
2. The name of this project is  Q-CTRL Python Open Controls.

As this README has a different heading, I'm changing it to be the project name "Q-CTRL Python Open Controls".

Changes proposed in this pull request:

- Change header of the README to "Q-CTRL Python Open Controls".
