### PR TITLE
feat: Enforce non-negativity of Rabi rotations

### DIFF
--- a/qctrlopencontrols/dynamic_decoupling_sequences/dynamic_decoupling_sequence.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/dynamic_decoupling_sequence.py
@@ -95,6 +95,13 @@ class DynamicDecouplingSequence:
             {"offsets": offsets, "duration": duration},
         )
 
+        rabi_rotations = np.asarray(rabi_rotations, dtype=np.float)
+        check_arguments(
+            np.all(rabi_rotations >= 0),
+            "rabi rotations must be non-negative. ",
+            {"rabi_rotations": rabi_rotations},
+        )
+
         _offset_count = len(offsets)
 
         check_arguments(
@@ -117,7 +124,7 @@ class DynamicDecouplingSequence:
 
         self.duration = duration
         self.offsets = offsets
-        self.rabi_rotations = np.asarray(rabi_rotations, dtype=np.float)
+        self.rabi_rotations = rabi_rotations
         self.azimuthal_angles = np.asarray(azimuthal_angles, dtype=np.float)
         self.detuning_rotations = np.asarray(detuning_rotations, dtype=np.float)
         self.name = name

--- a/qctrlopencontrols/dynamic_decoupling_sequences/dynamic_decoupling_sequence.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/dynamic_decoupling_sequence.py
@@ -98,7 +98,7 @@ class DynamicDecouplingSequence:
         rabi_rotations = np.asarray(rabi_rotations, dtype=np.float)
         check_arguments(
             np.all(rabi_rotations >= 0),
-            "rabi rotations must be non-negative. ",
+            "Rabi rotations must be non-negative.",
             {"rabi_rotations": rabi_rotations},
         )
 

--- a/tests/test_dynamical_decoupling.py
+++ b/tests/test_dynamical_decoupling.py
@@ -126,6 +126,17 @@ def test_dynamical_decoupling_sequence():
             detuning_rotations=np.zeros((2000, 1)),
         )
 
+    with pytest.raises(ArgumentsValueError):
+
+        # rabi rotations cannot be negative
+        _ = DynamicDecouplingSequence(
+            duration=2.0,
+            offsets=np.ones((2, 1)),
+            rabi_rotations=np.asarray([1, -1]),
+            azimuthal_angles=np.ones((2, 1)),
+            detuning_rotations=np.zeros((2, 1)),
+        )
+
 
 def test_sequence_plot():
     """


### PR DESCRIPTION
Changes proposed in this pull request:

- Enforce non-negativity of Rabi rotations during creation of a `DynamicDecouplingSequence` object
