### PR TITLE
feat: Make Open Controls compatible with Python 3.9

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -45,10 +45,10 @@ jobs:
       run: |
         source <(curl -sL http://ci.q-ctrl.com)
         ./ci vault login -r ${{ secrets.VAULT_ROLE_ID }} -s ${{ secrets.VAULT_SECRET_ID }}
-        ./ci docker run qctrl/python-build:${{ matrix.python }} /scripts/install-python-dependencies.sh
+        ./ci docker run qctrl/ci-images:python-${{ matrix.python }}-ci /scripts/install-python-dependencies.sh
     - name: Run Pytest
       run: |
-        ./ci docker run qctrl/python-build:${{ matrix.python }} /scripts/pytest.sh
+        ./ci docker run qctrl/ci-images:python-${{ matrix.python }}-ci /scripts/pytest.sh
 
   publish_internally:
     runs-on: ubuntu-latest

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.6, 3.7, 3.8]
+        python: [3.6, 3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v1
     - name: Install Python dependencies

--- a/poetry.lock
+++ b/poetry.lock
@@ -45,11 +45,11 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "attrs"
-version = "21.1.0"
+version = "21.2.0"
 description = "Classes Without Boilerplate"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.extras]
 dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit"]
@@ -1083,8 +1083,8 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 
 [metadata]
 lock-version = "1.1"
-python-versions = ">=3.6.4,<3.9"
-content-hash = "25210468e2350fa38d84dcaff3c3452f4bbc7ca26ef347bd94b797105f5e4423"
+python-versions = ">=3.6.4,<3.10"
+content-hash = "f312499bfd3932131cab4405ec47dd9f860cd00a967c9a308cd1c23b03e2c5af"
 
 [metadata.files]
 alabaster = [
@@ -1108,8 +1108,8 @@ atomicwrites = [
     {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
 ]
 attrs = [
-    {file = "attrs-21.1.0-py2.py3-none-any.whl", hash = "sha256:8ee1e5f5a1afc5b19bdfae4fdf0c35ed324074bdce3500c939842c8f818645d9"},
-    {file = "attrs-21.1.0.tar.gz", hash = "sha256:3901be1cb7c2a780f14668691474d9252c070a756be0a9ead98cfeabfa11aeb8"},
+    {file = "attrs-21.2.0-py2.py3-none-any.whl", hash = "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1"},
+    {file = "attrs-21.2.0.tar.gz", hash = "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"},
 ]
 babel = [
     {file = "Babel-2.9.1-py2.py3-none-any.whl", hash = "sha256:ab49e12b91d937cd11f0b67cb259a57ab4ad2b59ac7a3b41d6c06c0ac5b0def9"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]  # https://poetry.eustace.io/docs/versions
-python = ">=3.6.4,<3.9"
+python = ">=3.6.4,<3.10"
 numpy = "^1.16"
 toml = "^0.10.0"
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     name='qctrl-open-controls',
     version='8.1.0',
     description='Q-CTRL Python Open Controls',
-    python_requires='<3.9,>=3.6.4',
+    python_requires='<3.10,>=3.6.4',
     project_urls={"documentation": "https://docs.q-ctrl.com/references/python/qctrl-open-controls/", "homepage": "https://q-ctrl.com", "repository": "https://github.com/qctrl/python-open-controls"},
     author='Q-CTRL',
     author_email='support@q-ctrl.com',


### PR DESCRIPTION
I tried locally in my computer, and this seems to run fine in Python 3.9, so I don't think we need to restrict our users to older versions of Python.

Changes proposed in this pull request:

- Lift restriction that Open Controls is only compatible with Python < 3.9
- Add unit tests for Python 3.9 in the CI.
- Update name of the docker images in the CI.