### PR TITLE
misc: Update pyproject.toml comment to avoid dephell

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,9 @@ build-backend = "poetry.masonry.api"
 
 #  _______________________________________
 # / If you update this file, please run   \
-# \ poetry update && dephell deps convert /
+# | `poetry update --lock` to update the  |
+# | file "poetry.lock". The CI will then  |
+# \ automatically update "setup.py".      /
 #  ---------------------------------------
 #        \   ^__^
 #         \  (oo)\_______


### PR DESCRIPTION
The "housekeeping" workflow from the CI will automatically update `setup.py`, so it's no longer necessary to advise users to install and run `dephell`, a package that has been discontinued (https://github.com/dephell/dephell/#the-project-is-archived) and which is not compatible with the latest versions of `pip` (https://github.com/dephell/dephell/blob/master/pyproject.toml#L151).

Changes proposed in this pull request:

- Update pyproject.toml comment to no longer recommend running dephell.