### PR TITLE
Bugfix broken links

### DIFF
--- a/examples/creating-a-driven-control.ipynb
+++ b/examples/creating-a-driven-control.ipynb
@@ -46,17 +46,17 @@
     "\n",
     "Q-CTRL Open Controls can create driven controls according to the following dynamically corrected gate protocols:\n",
     "\n",
-    "1. [Primitive](https://docs.q-ctrl.com/references/python/qctrl-open-controls/qctrlopencontrols/new_primitive_control.html)\n",
-    "2. [BB1](https://docs.q-ctrl.com/references/python/qctrl-open-controls/qctrlopencontrols/new_bb1_control.html)\n",
-    "3. [SK1](https://docs.q-ctrl.com/references/python/qctrl-open-controls/qctrlopencontrols/new_sk1_control.html)\n",
-    "4. [CORPSE](https://docs.q-ctrl.com/references/python/qctrl-open-controls/qctrlopencontrols/new_corpse_control.html)\n",
-    "5. [WAMF1](https://docs.q-ctrl.com/references/python/qctrl-open-controls/qctrlopencontrols/new_wamf1_control.html)\n",
-    "6. [SCROFULOUS](https://docs.q-ctrl.com/references/python/qctrl-open-controls/qctrlopencontrols/new_scrofulous_control.html)\n",
-    "7. [CORPSE in BB1](https://docs.q-ctrl.com/references/python/qctrl-open-controls/qctrlopencontrols/new_corpse_in_bb1_control.html)\n",
-    "8. [CORPSE in SK1](https://docs.q-ctrl.com/references/python/qctrl-open-controls/qctrlopencontrols/new_corpse_in_sk1_control.html)\n",
-    "9. [CORPSE in SCROFULOUS](https://docs.q-ctrl.com/references/python/qctrl-open-controls/qctrlopencontrols/new_corpse_in_scrofulous_control.html)\n",
+    "1. [Primitive](https://docs.q-ctrl.com/open-controls/references/qctrl-open-controls/qctrlopencontrols/new_primitive_control.html)\n",
+    "2. [BB1](https://docs.q-ctrl.com/open-controls/references/qctrl-open-controls/qctrlopencontrols/new_bb1_control.html)\n",
+    "3. [SK1](https://docs.q-ctrl.com/open-controls/references/qctrl-open-controls/qctrlopencontrols/new_sk1_control.html)\n",
+    "4. [CORPSE](https://docs.q-ctrl.com/open-controls/references/qctrl-open-controls/qctrlopencontrols/new_corpse_control.html)\n",
+    "5. [WAMF1](https://docs.q-ctrl.com/open-controls/references/qctrl-open-controls/qctrlopencontrols/new_wamf1_control.html)\n",
+    "6. [SCROFULOUS](https://docs.q-ctrl.com/open-controls/references/qctrl-open-controls/qctrlopencontrols/new_scrofulous_control.html)\n",
+    "7. [CORPSE in BB1](https://docs.q-ctrl.com/open-controls/references/qctrl-open-controls/qctrlopencontrols/new_corpse_in_bb1_control.html)\n",
+    "8. [CORPSE in SK1](https://docs.q-ctrl.com/open-controls/references/qctrl-open-controls/qctrlopencontrols/new_corpse_in_sk1_control.html)\n",
+    "9. [CORPSE in SCROFULOUS](https://docs.q-ctrl.com/open-controls/references/qctrl-open-controls/qctrlopencontrols/new_corpse_in_scrofulous_control.html)\n",
     "\n",
-    "See the [documentation](https://docs.q-ctrl.com/references/python/qctrl-open-controls/qctrlopencontrols.html) for details."
+    "See the [documentation](https://docs.q-ctrl.com/open-controls/references/qctrl-open-controls/qctrlopencontrols.html) for details."
    ]
   },
   {
@@ -65,9 +65,9 @@
    "source": [
     "## Creating and printing a driven control\n",
     "\n",
-    "A driven control is made of a continuous drive on the qubit transition with a tunable detuning. The continuous drive is described by a piecewise constant function made of a list of segments. Each drive segment has a `rabi_rate` applied at an `azimuthal_angle` for a `duration`, with a `detuning`. The mathematical definition of a driven control is explained in the [documentation](https://docs.q-ctrl.com/references/python/qctrl-open-controls/qctrlopencontrols/DrivenControl.html).\n",
+    "A driven control is made of a continuous drive on the qubit transition with a tunable detuning. The continuous drive is described by a piecewise constant function made of a list of segments. Each drive segment has a `rabi_rate` applied at an `azimuthal_angle` for a `duration`, with a `detuning`. The mathematical definition of a driven control is explained in the [documentation](https://docs.q-ctrl.com/open-controls/references/qctrl-open-controls/qctrlopencontrols/DrivenControl.html).\n",
     "\n",
-    "Q-CTRL Open Controls can generate a driven control from a library of dynamically corrected gate schemes, mathematically defined in the [documentation](https://docs.q-ctrl.com/references/python/qctrl-open-controls/qctrlopencontrols/DynamicDecouplingSequence.html#). All dynamically corrected gates are derived from three quantities: \n",
+    "Q-CTRL Open Controls can generate a driven control from a library of dynamically corrected gate schemes, mathematically defined in the [documentation](https://docs.q-ctrl.com/open-controls/references/qctrl-open-controls/qctrlopencontrols/DynamicDecouplingSequence.html#). All dynamically corrected gates are derived from three quantities: \n",
     "\n",
     "* `rabi_rotation` the total rotation of the Bloch sphere,\n",
     "* `azimuthal_angle` the angle to the center point of the rotation on the equator,\n",
@@ -253,9 +253,9 @@
    "source": [
     "### Exporting a Driven Control\n",
     "\n",
-    "Q-CTRL Open Controls enables exporting driven controls in CSV or JSON format. An exported driven control is [formatted](https://docs.q-ctrl.com/wiki/control-formats) to be compatible with [Q-CTRL BLACK OPAL](https://app.q-ctrl.com).\n",
+    "Q-CTRL Open Controls enables exporting driven controls in CSV or JSON format. An exported driven control is formatted to be compatible with [Q-CTRL BLACK OPAL](https://app.q-ctrl.com).\n",
     "\n",
-    "Q-CTRL Open Controls can export a driven control in either `cartesian` or `cylindrical` coordinates. For details, consult the [documentation](https://docs.q-ctrl.com/wiki/output-data-formats#q-ctrl-hardware).\n",
+    "Q-CTRL Open Controls can export a driven control in either `cartesian` or `cylindrical` coordinates. For details, consult the [documentation](https://docs.q-ctrl.com/open-controls/references/qctrl-open-controls/qctrlopencontrols/DrivenControl.export_to_file.html).\n",
     "\n",
     "In the example below, we chose the `bb1_x` control (created above) for exporting to a CSV file."
    ]

--- a/examples/creating-a-dynamical-decoupling-sequence.ipynb
+++ b/examples/creating-a-dynamical-decoupling-sequence.ipynb
@@ -58,7 +58,7 @@
     "9. `X concatenated`\n",
     "10. `XY concatenated`\n",
     "\n",
-    "See the [documentation](https://docs.q-ctrl.com/references/python/qctrl-open-controls/qctrlopencontrols.html) for details."
+    "See the [documentation](https://docs.q-ctrl.com/open-controls/references/qctrl-open-controls/qctrlopencontrols.html) for details."
    ]
   },
   {
@@ -67,9 +67,9 @@
    "source": [
     "## Creating and printing a DDS\n",
     "\n",
-    "A DDS is defined as a set of instant unitary operations, each defined by a `rabi_rotation`, `azimuthal_angle`, `detuning_angle`, and `offset` (giving the time at which the operation is applied). The mathematical definition of a sequence is explained in the [documentation](https://docs.q-ctrl.com/references/python/qctrl-open-controls/qctrlopencontrols.html#qctrlopencontrols.DynamicDecouplingSequence).\n",
+    "A DDS is defined as a set of instant unitary operations, each defined by a `rabi_rotation`, `azimuthal_angle`, `detuning_angle`, and `offset` (giving the time at which the operation is applied). The mathematical definition of a sequence is explained in the [documentation](https://docs.q-ctrl.com/open-controls/references/qctrl-open-controls/qctrlopencontrols/DynamicDecouplingSequence.html#qctrlopencontrols.DynamicDecouplingSequence).\n",
     "\n",
-    "Q-CTRL Open controls provides a set of functions to generate commonly used DDSs. For each sequence, the detailed mathematical definition can be found in the [documentation](https://docs.q-ctrl.com/references/python/qctrl-open-controls/qctrlopencontrols.html#qctrlopencontrols).\n",
+    "Q-CTRL Open controls provides a set of functions to generate commonly used DDSs. For each sequence, the detailed mathematical definition can be found in the [documentation](https://docs.q-ctrl.com/open-controls/references/qctrl-open-controls/qctrlopencontrols.html#qctrlopencontrols).\n",
     "Below we give a few examples of generating DDSs."
    ]
   },
@@ -270,11 +270,11 @@
    "source": [
     "### Exporting the DDS\n",
     "\n",
-    "Q-CTRL Open Controls enables exporting DDS in CSV or JSON format. An exported sequence is [formatted](https://docs.q-ctrl.com/wiki/control-formats) to be compatible with [Q-CTRL BLACK OPAL](https://app.q-ctrl.com).\n",
+    "Q-CTRL Open Controls enables exporting DDS in CSV or JSON format. An exported sequence is formatted to be compatible with [Q-CTRL BLACK OPAL](https://app.q-ctrl.com).\n",
     "\n",
     "An ideal DDS is defined as a sequence of instantaneously-applied pulses, which correspond to instantaneous rotations of the Bloch sphere. However, in reality, the rate of rotation is limited by the `maximum_rabi_rate` and/or `maximum_detuning_rate` for a given pulse. Due to this limiting factor, the target rotation is implemented over a control segment with finite duration. Q-CTRL Open Controls converts a `DynamicDecouplingSequence` into a `DrivenControl` before exporting the resulting `DrivenControl`. This conversion requires the `maximum_rabi_rate` and `maximum_detuning_rate` to be specified and raises an error if the conversion is not successful (e.g. if control segments overlap due to a low `maximum_rabi_rate` or `maximum_detuning_rate`).\n",
     "\n",
-    "Q-CTRL Open Controls can export a sequence in either `cartesian` or `cylindrical` coordinates. For details, consult the [documentation](https://docs.q-ctrl.com/wiki/output-data-formats#q-ctrl-hardware).\n",
+    "Q-CTRL Open Controls can export a sequence in either `cartesian` or `cylindrical` coordinates. For details, consult the [documentation](https://docs.q-ctrl.com/open-controls/references/qctrl-open-controls/qctrlopencontrols/DrivenControl.export_to_file.html).\n",
     "\n",
     "In the example below, we chose the `quadratic_dds` (created above) for exporting to a CSV file."
    ]


### PR DESCRIPTION
Addresses: https://q-ctrl.atlassian.net/browse/(ticket)

Resolves #197.

Changes proposed in this pull request:

- Fixes broken links in example notebooks.

## TODO
- Address broken links in the section titled 'Opening the exported sequence in Q-CTRL BLACK OPAL' of [creating-a-dynamical-decoupling-sequence.ipynb](https://github.com/qctrl/python-open-controls/blob/291bb40e19042739f4fdcf1a3065a20c40b80ef9/examples/creating-a-dynamical-decoupling-sequence.ipynb).