### PR TITLE
feat: Add function to resample a driven control

### DIFF
--- a/qctrlopencontrols/driven_controls/driven_control.py
+++ b/qctrlopencontrols/driven_controls/driven_control.py
@@ -24,7 +24,6 @@ from typing import (
 
 import numpy as np
 
-from ..exceptions import ArgumentsValueError
 from ..utils import (
     Coordinate,
     FileFormat,
@@ -331,13 +330,13 @@ class DrivenControl:
 
         return np.sum(self.durations)
 
-    def resample(self, dt: float, name: Optional[str] = None) -> "DrivenControl":
+    def resample(self, time_step: float, name: Optional[str] = None) -> "DrivenControl":
         r"""
         Returns a new driven control obtained by resampling this control.
 
         Parameters
         ----------
-        dt : float
+        time_step : float
             The time step to use for resampling, :math:`\delta t`.
         name : str, optional
             The name for the new control. Defaults to ``None``.
@@ -351,20 +350,20 @@ class DrivenControl:
             original duration.
         """
         check_arguments(
-            dt > 0,
+            time_step > 0,
             "Time step must be positive.",
-            {"dt": dt},
+            {"time_step": time_step},
         )
         check_arguments(
-            dt <= self.duration,
+            time_step <= self.duration,
             "Time step must be less than or equal to the original duration.",
-            {"dt": dt},
+            {"time_step": time_step},
             {"duration": self.duration},
         )
 
-        count = int(np.ceil(self.duration / dt))
-        durations = [dt] * count
-        times = np.arange(count) * dt
+        count = int(np.ceil(self.duration / time_step))
+        durations = [time_step] * count
+        times = np.arange(count) * time_step
 
         indices = np.digitize(times, bins=np.cumsum(self.durations))
 

--- a/qctrlopencontrols/driven_controls/driven_control.py
+++ b/qctrlopencontrols/driven_controls/driven_control.py
@@ -377,14 +377,6 @@ class DrivenControl:
             {"sample_times": sample_times},
         )
 
-        coordinate_systems = [v.value for v in Coordinate]
-        check_arguments(
-            coordinates in coordinate_systems,
-            "Requested coordinate type is not supported. Please use "
-            "one of {}".format(coordinate_systems),
-            {"coordinates": coordinates},
-        )
-
         indices = np.digitize(times, bins=np.cumsum(self.durations), right=True)
 
         if coordinates == Coordinate.CARTESIAN.value:

--- a/tests/test_driven_controls.py
+++ b/tests/test_driven_controls.py
@@ -406,3 +406,87 @@ def test_pretty_print():
     expected_string = "\n".join(_pretty_string)
 
     assert str(driven_control) == expected_string
+
+
+def test_sample_dt_cylindrical():
+    driven_control = DrivenControl(
+        rabi_rates=[0, 2],
+        azimuthal_angles=[1.5, 0.5],
+        detunings=[1.3, 2.3],
+        durations=[1, 1],
+        name="control",
+    )
+
+    rabi_rates, azimuthal_angles, detunings = driven_control.sample(0.3)
+
+    assert len(rabi_rates) == 7
+    assert len(azimuthal_angles) == 7
+    assert len(detunings) == 7
+
+    assert np.allclose(rabi_rates, [0, 0, 0, 0, 2, 2, 2])
+    assert np.allclose(azimuthal_angles, [1.5, 1.5, 1.5, 1.5, 0.5, 0.5, 0.5])
+    assert np.allclose(detunings, [1.3, 1.3, 1.3, 1.3, 2.3, 2.3, 2.3])
+
+
+def test_sample_dt_cartesian():
+    driven_control = DrivenControl(
+        rabi_rates=[3, 2],
+        azimuthal_angles=[0, np.pi / 2],
+        detunings=[1.3, 2.3],
+        durations=[1, 1],
+        name="control",
+    )
+
+    x_amplitudes, y_amplitudes, detunings = driven_control.sample(0.3, "cartesian")
+
+    assert len(x_amplitudes) == 7
+    assert len(y_amplitudes) == 7
+    assert len(detunings) == 7
+
+    assert np.allclose(x_amplitudes, [3, 3, 3, 3, 0, 0, 0])
+    assert np.allclose(y_amplitudes, [0, 0, 0, 0, 2, 2, 2])
+    assert np.allclose(detunings, [1.3, 1.3, 1.3, 1.3, 2.3, 2.3, 2.3])
+
+
+def test_sample_cylindrical():
+    driven_control = DrivenControl(
+        rabi_rates=[0, 2],
+        azimuthal_angles=[1.5, 0.5],
+        detunings=[1.3, 2.3],
+        durations=[1, 1],
+        name="control",
+    )
+
+    rabi_rates, azimuthal_angles, detunings = driven_control.sample(
+        np.array([0.5, 0.8, 1.5])
+    )
+
+    assert len(rabi_rates) == 3
+    assert len(azimuthal_angles) == 3
+    assert len(detunings) == 3
+
+    assert np.allclose(rabi_rates, [0, 0, 2])
+    assert np.allclose(azimuthal_angles, [1.5, 1.5, 0.5])
+    assert np.allclose(detunings, [1.3, 1.3, 2.3])
+
+
+def test_sample_cartesian():
+    driven_control = DrivenControl(
+        rabi_rates=[3, 2],
+        azimuthal_angles=[0, np.pi / 2],
+        detunings=[1.3, 2.3],
+        durations=[1, 1],
+        name="control",
+    )
+
+    x_amplitudes, y_amplitudes, detunings = driven_control.sample(
+        np.array([0.5, 0.8, 1.5]), "cartesian"
+    )
+
+    assert len(x_amplitudes) == 3
+    assert len(y_amplitudes) == 3
+    assert len(detunings) == 3
+
+    assert np.allclose(x_amplitudes, [3, 3, 0])
+    assert np.allclose(y_amplitudes, [0, 0, 2])
+    assert np.allclose(detunings, [1.3, 1.3, 2.3])

--- a/tests/test_driven_controls.py
+++ b/tests/test_driven_controls.py
@@ -408,7 +408,7 @@ def test_pretty_print():
     assert str(driven_control) == expected_string
 
 
-def test_sample_dt_cylindrical():
+def test_resample_exact():
     driven_control = DrivenControl(
         rabi_rates=[0, 2],
         azimuthal_angles=[1.5, 0.5],
@@ -417,38 +417,17 @@ def test_sample_dt_cylindrical():
         name="control",
     )
 
-    rabi_rates, azimuthal_angles, detunings = driven_control.sample(0.3)
+    new_driven_control = driven_control.resample(0.5)
 
-    assert len(rabi_rates) == 7
-    assert len(azimuthal_angles) == 7
-    assert len(detunings) == 7
+    assert len(new_driven_control.durations) == 4
 
-    assert np.allclose(rabi_rates, [0, 0, 0, 0, 2, 2, 2])
-    assert np.allclose(azimuthal_angles, [1.5, 1.5, 1.5, 1.5, 0.5, 0.5, 0.5])
-    assert np.allclose(detunings, [1.3, 1.3, 1.3, 1.3, 2.3, 2.3, 2.3])
-
-
-def test_sample_dt_cartesian():
-    driven_control = DrivenControl(
-        rabi_rates=[3, 2],
-        azimuthal_angles=[0, np.pi / 2],
-        detunings=[1.3, 2.3],
-        durations=[1, 1],
-        name="control",
-    )
-
-    x_amplitudes, y_amplitudes, detunings = driven_control.sample(0.3, "cartesian")
-
-    assert len(x_amplitudes) == 7
-    assert len(y_amplitudes) == 7
-    assert len(detunings) == 7
-
-    assert np.allclose(x_amplitudes, [3, 3, 3, 3, 0, 0, 0])
-    assert np.allclose(y_amplitudes, [0, 0, 0, 0, 2, 2, 2])
-    assert np.allclose(detunings, [1.3, 1.3, 1.3, 1.3, 2.3, 2.3, 2.3])
+    assert np.allclose(new_driven_control.durations, 0.5)
+    assert np.allclose(new_driven_control.rabi_rates, [0, 0, 2, 2])
+    assert np.allclose(new_driven_control.azimuthal_angles, [1.5, 1.5, 0.5, 0.5])
+    assert np.allclose(new_driven_control.detunings, [1.3, 1.3, 2.3, 2.3])
 
 
-def test_sample_cylindrical():
+def test_resample_inexact():
     driven_control = DrivenControl(
         rabi_rates=[0, 2],
         azimuthal_angles=[1.5, 0.5],
@@ -457,36 +436,15 @@ def test_sample_cylindrical():
         name="control",
     )
 
-    rabi_rates, azimuthal_angles, detunings = driven_control.sample(
-        np.array([0.5, 0.8, 1.5])
+    new_driven_control = driven_control.resample(0.3)
+
+    assert len(new_driven_control.durations) == 7
+
+    assert np.allclose(new_driven_control.durations, 0.3)
+    assert np.allclose(new_driven_control.rabi_rates, [0, 0, 0, 0, 2, 2, 2])
+    assert np.allclose(
+        new_driven_control.azimuthal_angles, [1.5, 1.5, 1.5, 1.5, 0.5, 0.5, 0.5]
     )
-
-    assert len(rabi_rates) == 3
-    assert len(azimuthal_angles) == 3
-    assert len(detunings) == 3
-
-    assert np.allclose(rabi_rates, [0, 0, 2])
-    assert np.allclose(azimuthal_angles, [1.5, 1.5, 0.5])
-    assert np.allclose(detunings, [1.3, 1.3, 2.3])
-
-
-def test_sample_cartesian():
-    driven_control = DrivenControl(
-        rabi_rates=[3, 2],
-        azimuthal_angles=[0, np.pi / 2],
-        detunings=[1.3, 2.3],
-        durations=[1, 1],
-        name="control",
+    assert np.allclose(
+        new_driven_control.detunings, [1.3, 1.3, 1.3, 1.3, 2.3, 2.3, 2.3]
     )
-
-    x_amplitudes, y_amplitudes, detunings = driven_control.sample(
-        np.array([0.5, 0.8, 1.5]), "cartesian"
-    )
-
-    assert len(x_amplitudes) == 3
-    assert len(y_amplitudes) == 3
-    assert len(detunings) == 3
-
-    assert np.allclose(x_amplitudes, [3, 3, 0])
-    assert np.allclose(y_amplitudes, [0, 0, 2])
-    assert np.allclose(detunings, [1.3, 1.3, 2.3])


### PR DESCRIPTION
Alternative to https://github.com/qctrl/python-open-controls/pull/200. Even though this one is a bit less consistent with BOULDER OPAL, I think it's better. For a start, it means the user can also benefit from resampling for the export-to-file function too, which I would have thought should be very useful. Also, I don't think consistency with BOULDER OPAL is that important here, because DrivenControl is a very different beast to a plain old pulse.