### PR TITLE
misc: Remove Python3.6 from on-PR workflow

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.6, 3.7, 3.8]
+        python: [3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v1
     - name: Install Python dependencies


### PR DESCRIPTION
It seems I forgot to remove python 3.6 from the on-pull-request workflow and causing an issue in #209 .