### PR TITLE
misc: Update Docker image names

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Ensure no development packages have been set
         run: |
           source <(curl -sL http://ci.q-ctrl.com)
-          ./ci docker run qctrl/python-build:3.7 /scripts/check-for-internal-versions.sh
+          ./ci docker run qctrl/ci-images:python-3.7-ci /scripts/check-for-internal-versions.sh
   linting:
     # Filter out PRs originating from this repository (triggers on-push.yml instead)
     if: github.event.pull_request.head.repo.fork == true
@@ -46,10 +46,10 @@ jobs:
     - name: Install Python dependencies
       run: |
         source <(curl -sL http://ci.q-ctrl.com)
-        ./ci docker run qctrl/python-build:${{ matrix.python }} /scripts/install-python-dependencies.sh
+        ./ci docker run qctrl/ci-images:python-${{ matrix.python }}-ci /scripts/install-python-dependencies.sh
     - name: Run Pytest
       run: |
-        ./ci docker run qctrl/python-build:${{ matrix.python }} /scripts/pytest.sh
+        ./ci docker run qctrl/ci-images:python-${{ matrix.python }}-ci /scripts/pytest.sh
   sphinx_documentation:
     # Filter out PRs originating from this repository (triggers on-push.yml instead)
     if: github.event.pull_request.head.repo.fork == true

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -19,7 +19,7 @@ jobs:
       run: |
         source <(curl -sL http://ci.q-ctrl.com)
         ./ci vault login -r ${{ secrets.VAULT_ROLE_ID }} -s ${{ secrets.VAULT_SECRET_ID }}
-        ./ci docker run qctrl/python-build:3.7 /scripts/housekeeping.sh
+        ./ci docker run qctrl/ci-images:python-3.7-ci /scripts/housekeeping.sh
 
   linting:
     runs-on: ubuntu-latest
@@ -60,7 +60,7 @@ jobs:
       run: |
         source <(curl -sL http://ci.q-ctrl.com)
         ./ci vault login -r ${{ secrets.VAULT_ROLE_ID }} -s ${{ secrets.VAULT_SECRET_ID }}
-        ./ci docker run qctrl/python-build:3.7 /scripts/publish-dev-version.sh
+        ./ci docker run qctrl/ci-images:python-3.7-ci /scripts/publish-dev-version.sh
 
   sphinx_documentation:
     runs-on: ubuntu-latest

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -16,16 +16,16 @@ jobs:
       run: |
         source <(curl -sL http://ci.q-ctrl.com)
         ./ci vault login -r ${{ secrets.VAULT_ROLE_ID }} -s ${{ secrets.VAULT_SECRET_ID }}
-        ./ci docker run qctrl/python-build:3.7 /scripts/housekeeping.sh
+        ./ci docker run qctrl/ci-images:python-3.7-ci /scripts/housekeeping.sh
     - name: Publish publicly
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         source <(curl -sL http://ci.q-ctrl.com)
-        ./ci docker run qctrl/python-build:3.7 /scripts/publish-release-publicly.sh
+        ./ci docker run qctrl/ci-images:python-3.7-ci /scripts/publish-release-publicly.sh
     - name: Publish internally
       run: |
-        ./ci docker run qctrl/python-build:3.7 /scripts/publish-release-internally.sh
+        ./ci docker run qctrl/ci-images:python-3.7-ci /scripts/publish-release-internally.sh
 
   sphinx_documentation:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Some workflows like https://github.com/qctrl/python-open-controls/runs/4553896326 seem to be failing due to out-of-date image names. This should update the pattern of the image names from `python-build:3.7` to `ci-images:python-3.7-ci` throughout the workflows.

Changes proposed in this pull request:
- Update the name of the Docker images in the CI.