### PR TITLE
fix: Fix type issue with NumPy

### DIFF
--- a/qctrlopencontrols/constants.py
+++ b/qctrlopencontrols/constants.py
@@ -18,11 +18,11 @@ Defines commonly used constants.
 
 import numpy as np
 
-SIGMA_X = np.array([[0.0, 1.0], [1.0, 0.0]], dtype=np.complex)
-SIGMA_Y = np.array([[0.0, -1.0j], [1.0j, 0.0]], dtype=np.complex)
-SIGMA_Z = np.array([[1.0, 0.0], [0.0, -1.0]], dtype=np.complex)
-SIGMA_M = np.array([[0.0, 1.0], [0.0, 0.0]], dtype=np.complex)
-SIGMA_P = np.array([[0.0, 0.0], [1.0, 0.0]], dtype=np.complex)
+SIGMA_X = np.array([[0.0, 1.0], [1.0, 0.0]], dtype=complex)
+SIGMA_Y = np.array([[0.0, -1.0j], [1.0j, 0.0]], dtype=complex)
+SIGMA_Z = np.array([[1.0, 0.0], [0.0, -1.0]], dtype=complex)
+SIGMA_M = np.array([[0.0, 1.0], [0.0, 0.0]], dtype=complex)
+SIGMA_P = np.array([[0.0, 0.0], [1.0, 0.0]], dtype=complex)
 
 # Matplotlib format of data for plotting
 MATPLOTLIB = "matplotlib"

--- a/qctrlopencontrols/driven_controls/driven_control.py
+++ b/qctrlopencontrols/driven_controls/driven_control.py
@@ -102,7 +102,7 @@ class DrivenControl:
 
         self.name = name
 
-        durations = np.asarray(durations, dtype=np.float)
+        durations = np.asarray(durations, dtype=float)
 
         # check if all the durations are greater than zero
         check_arguments(
@@ -139,9 +139,10 @@ class DrivenControl:
         if detunings is None:
             detunings = np.zeros(duration_count)
 
-        rabi_rates = np.asarray(rabi_rates, dtype=np.float64)
-        azimuthal_angles = np.asarray(azimuthal_angles, dtype=np.float64)
-        detunings = np.asarray(detunings, dtype=np.float64)
+        # for backward compatibility as these variable could be list
+        rabi_rates = np.asarray(rabi_rates, dtype=float)
+        azimuthal_angles = np.asarray(azimuthal_angles, dtype=float)
+        detunings = np.asarray(detunings, dtype=float)
 
         # check if all the rabi_rates are greater than zero
         check_arguments(
@@ -362,7 +363,7 @@ class DrivenControl:
         )
 
         count = int(np.ceil(self.duration / time_step))
-        durations = [time_step] * count
+        durations = np.repeat(time_step, count)
         times = np.arange(count) * time_step
 
         indices = np.digitize(times, bins=np.cumsum(self.durations))

--- a/qctrlopencontrols/driven_controls/predefined.py
+++ b/qctrlopencontrols/driven_controls/predefined.py
@@ -150,10 +150,10 @@ def new_primitive_control(
     )
 
     return DrivenControl(
-        rabi_rates=[maximum_rabi_rate],
-        azimuthal_angles=[azimuthal_angle],
-        detunings=[0],
-        durations=[rabi_rotation / maximum_rabi_rate],
+        rabi_rates=np.array([maximum_rabi_rate]),
+        azimuthal_angles=np.array([azimuthal_angle]),
+        detunings=np.array([0]),
+        durations=np.array([rabi_rotation / maximum_rabi_rate]),
         name=name,
     )
 
@@ -216,15 +216,19 @@ def new_bb1_control(
     phi_p = _get_transformed_rabi_rotation_wimperis(rabi_rotation)
     rabi_rotations = [rabi_rotation, np.pi, 2 * np.pi, np.pi]
 
-    rabi_rates = [maximum_rabi_rate] * 4
-    azimuthal_angles = [
-        azimuthal_angle,
-        azimuthal_angle + phi_p,
-        azimuthal_angle + 3 * phi_p,
-        azimuthal_angle + phi_p,
-    ]
-    detunings = [0] * 4
-    durations = [rabi_rotation / maximum_rabi_rate for rabi_rotation in rabi_rotations]
+    rabi_rates = np.repeat(maximum_rabi_rate, 4)
+    azimuthal_angles = np.asarray(
+        [
+            azimuthal_angle,
+            azimuthal_angle + phi_p,
+            azimuthal_angle + 3 * phi_p,
+            azimuthal_angle + phi_p,
+        ]
+    )
+    detunings = np.repeat(0, 4)
+    durations = np.asarray(
+        [rabi_rotation / maximum_rabi_rate for rabi_rotation in rabi_rotations]
+    )
 
     return DrivenControl(
         rabi_rates=rabi_rates,
@@ -294,16 +298,18 @@ def new_sk1_control(
     phi_p = _get_transformed_rabi_rotation_wimperis(rabi_rotation)
     rabi_rotations = [rabi_rotation, 2 * np.pi, 2 * np.pi]
 
-    rabi_rates = [maximum_rabi_rate] * 3
-    azimuthal_angles = [
-        azimuthal_angle,
-        azimuthal_angle - phi_p,
-        azimuthal_angle + phi_p,
-    ]
-    detunings = [0] * 3
-    durations = [
-        rabi_rotation_ / maximum_rabi_rate for rabi_rotation_ in rabi_rotations
-    ]
+    rabi_rates = np.repeat(maximum_rabi_rate, 3)
+    azimuthal_angles = np.asarray(
+        [
+            azimuthal_angle,
+            azimuthal_angle - phi_p,
+            azimuthal_angle + phi_p,
+        ]
+    )
+    detunings = np.repeat(0, 3)
+    durations = np.asarray(
+        [rabi_rotation_ / maximum_rabi_rate for rabi_rotation_ in rabi_rotations]
+    )
 
     return DrivenControl(
         rabi_rates=rabi_rates,
@@ -414,16 +420,18 @@ def new_scrofulous_control(
 
     rabi_rotations = [theta_1, theta_2, theta_3]
 
-    rabi_rates = [maximum_rabi_rate] * 3
-    azimuthal_angles = [
-        azimuthal_angle + phi_1,
-        azimuthal_angle + phi_2,
-        azimuthal_angle + phi_3,
-    ]
-    detunings = [0] * 3
-    durations = [
-        rabi_rotation_ / maximum_rabi_rate for rabi_rotation_ in rabi_rotations
-    ]
+    rabi_rates = np.repeat(maximum_rabi_rate, 3)
+    azimuthal_angles = np.asarray(
+        [
+            azimuthal_angle + phi_1,
+            azimuthal_angle + phi_2,
+            azimuthal_angle + phi_3,
+        ]
+    )
+    detunings = np.repeat(0, 3)
+    durations = np.asarray(
+        [rabi_rotation_ / maximum_rabi_rate for rabi_rotation_ in rabi_rotations]
+    )
 
     return DrivenControl(
         rabi_rates=rabi_rates,
@@ -500,12 +508,14 @@ def new_corpse_control(
         rabi_rotation / 2.0 - k,
     ]
 
-    rabi_rates = [maximum_rabi_rate] * 3
-    azimuthal_angles = [azimuthal_angle, azimuthal_angle + np.pi, azimuthal_angle]
-    detunings = [0] * 3
-    durations = [
-        rabi_rotation_ / maximum_rabi_rate for rabi_rotation_ in rabi_rotations
-    ]
+    rabi_rates = np.repeat(maximum_rabi_rate, 3)
+    azimuthal_angles = np.asarray(
+        [azimuthal_angle, azimuthal_angle + np.pi, azimuthal_angle]
+    )
+    detunings = np.repeat(0, 3)
+    durations = np.asarray(
+        [rabi_rotation_ / maximum_rabi_rate for rabi_rotation_ in rabi_rotations]
+    )
 
     return DrivenControl(
         rabi_rates=rabi_rates,
@@ -598,19 +608,21 @@ def new_corpse_in_bb1_control(
         np.pi,
     ]
 
-    rabi_rates = [maximum_rabi_rate] * 6
-    azimuthal_angles = [
-        azimuthal_angle,
-        azimuthal_angle + np.pi,
-        azimuthal_angle,
-        azimuthal_angle + phi_p,
-        azimuthal_angle + 3 * phi_p,
-        azimuthal_angle + phi_p,
-    ]
-    detunings = [0] * 6
-    durations = [
-        rabi_rotation_ / maximum_rabi_rate for rabi_rotation_ in rabi_rotations
-    ]
+    rabi_rates = np.repeat(maximum_rabi_rate, 6)
+    azimuthal_angles = np.asarray(
+        [
+            azimuthal_angle,
+            azimuthal_angle + np.pi,
+            azimuthal_angle,
+            azimuthal_angle + phi_p,
+            azimuthal_angle + 3 * phi_p,
+            azimuthal_angle + phi_p,
+        ]
+    )
+    detunings = np.repeat(0, 6)
+    durations = np.asarray(
+        [rabi_rotation_ / maximum_rabi_rate for rabi_rotation_ in rabi_rotations]
+    )
 
     return DrivenControl(
         rabi_rates=rabi_rates,
@@ -701,18 +713,20 @@ def new_corpse_in_sk1_control(
         2 * np.pi,
     ]
 
-    rabi_rates = [maximum_rabi_rate] * 5
-    azimuthal_angles = [
-        azimuthal_angle,
-        azimuthal_angle + np.pi,
-        azimuthal_angle,
-        azimuthal_angle - phi_p,
-        azimuthal_angle + phi_p,
-    ]
-    detunings = [0] * 5
-    durations = [
-        rabi_rotation_ / maximum_rabi_rate for rabi_rotation_ in rabi_rotations
-    ]
+    rabi_rates = np.repeat(maximum_rabi_rate, 5)
+    azimuthal_angles = np.asarray(
+        [
+            azimuthal_angle,
+            azimuthal_angle + np.pi,
+            azimuthal_angle,
+            azimuthal_angle - phi_p,
+            azimuthal_angle + phi_p,
+        ]
+    )
+    detunings = np.repeat(0, 5)
+    durations = np.asarray(
+        [rabi_rotation_ / maximum_rabi_rate for rabi_rotation_ in rabi_rotations]
+    )
 
     return DrivenControl(
         rabi_rates=rabi_rates,
@@ -867,10 +881,12 @@ def new_corpse_in_scrofulous_control(
     total_angles = np.vstack(_total_angles)
     rabi_rotations = total_angles[:, 0]
 
-    rabi_rates = [maximum_rabi_rate] * 9
+    rabi_rates = np.repeat(maximum_rabi_rate, 9)
     azimuthal_angles = total_angles[:, 1]
-    detunings = [0] * 9
-    durations = [rabi_rotation / maximum_rabi_rate for rabi_rotation in rabi_rotations]
+    detunings = np.repeat(0, 9)
+    durations = np.asarray(
+        [rabi_rotation / maximum_rabi_rate for rabi_rotation in rabi_rotations]
+    )
 
     return DrivenControl(
         rabi_rates=rabi_rates,
@@ -959,10 +975,12 @@ def new_wamf1_control(
     rabi_rotations = [theta_plus, theta_minus, theta_minus, theta_plus]
     segment_duration = theta_plus / maximum_rabi_rate
 
-    rabi_rates = [rabi_rotation / segment_duration for rabi_rotation in rabi_rotations]
-    azimuthal_angles = [azimuthal_angle] * 4
-    detunings = [0] * 4
-    durations = [segment_duration] * 4
+    rabi_rates = np.asarray(
+        [rabi_rotation / segment_duration for rabi_rotation in rabi_rotations]
+    )
+    azimuthal_angles = np.repeat(azimuthal_angle, 4)
+    detunings = np.repeat(0, 4)
+    durations = np.repeat(segment_duration, 4)
 
     return DrivenControl(
         rabi_rates=rabi_rates,
@@ -1199,7 +1217,9 @@ def new_modulated_gaussian_control(
             * (maximum_full_rotation_angle / maximum_rotation_angle)
         )
 
-    azimuthal_angles = [0 if v >= 0 else np.pi for v in modulated_gaussian_segments]
+    azimuthal_angles = np.asarray(
+        [0 if v >= 0 else np.pi for v in modulated_gaussian_segments]
+    )
 
     return DrivenControl(
         rabi_rates=np.abs(modulated_gaussian_segments),

--- a/qctrlopencontrols/dynamic_decoupling_sequences/dynamic_decoupling_sequence.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/dynamic_decoupling_sequence.py
@@ -95,7 +95,7 @@ class DynamicDecouplingSequence:
             {"offsets": offsets, "duration": duration},
         )
 
-        rabi_rotations = np.asarray(rabi_rotations, dtype=np.float)
+        rabi_rotations = np.asarray(rabi_rotations, dtype=float)
         check_arguments(
             np.all(rabi_rotations >= 0),
             "Rabi rotations must be non-negative.",
@@ -125,8 +125,8 @@ class DynamicDecouplingSequence:
         self.duration = duration
         self.offsets = offsets
         self.rabi_rotations = rabi_rotations
-        self.azimuthal_angles = np.asarray(azimuthal_angles, dtype=np.float)
-        self.detuning_rotations = np.asarray(detuning_rotations, dtype=np.float)
+        self.azimuthal_angles = np.asarray(azimuthal_angles, dtype=float)
+        self.detuning_rotations = np.asarray(detuning_rotations, dtype=float)
         self.name = name
 
     def export(self) -> Dict:
@@ -474,10 +474,10 @@ def convert_dds_to_driven_control(
     if np.allclose(pulse_start_ends, 0.0):
         # the original sequence should be a free evolution
         return DrivenControl(
-            rabi_rates=[0.0],
-            azimuthal_angles=[0.0],
-            detunings=[0.0],
-            durations=[sequence_duration],
+            rabi_rates=np.array([0.0]),
+            azimuthal_angles=np.array([0.0]),
+            detunings=np.array([0.0]),
+            durations=np.array([sequence_duration]),
             name=name,
         )
 

--- a/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
@@ -103,9 +103,9 @@ def _add_pre_post_rotations(
 
     # parameters for pre-post pulses
     rabi_value = np.pi / 2
-    detuning_value = 0
-    initial_azimuthal = 0  # for pre-pulse
-    final_azimuthal = 0  # for post-pulse
+    detuning_value = 0.0
+    initial_azimuthal = 0.0  # for pre-pulse
+    final_azimuthal = 0.0  # for post-pulse
 
     # The sequence will preserve the state |0> is it has an even number
     # of X and Y pi-pulses
@@ -183,16 +183,16 @@ def new_ramsey_sequence(duration, pre_post_rotation=False, name=None):
         {"duration": duration},
     )
 
-    offsets = []
-    rabi_rotations = []
-    azimuthal_angles = []
-    detuning_rotations = []
-
     if pre_post_rotation:
         offsets = duration * np.array([0.0, 1.0])
         rabi_rotations = np.array([np.pi / 2, np.pi / 2])
         azimuthal_angles = np.array([0.0, np.pi])
         detuning_rotations = np.zeros((2,))
+    else:
+        offsets = np.array([])
+        rabi_rotations = np.array([])
+        azimuthal_angles = np.array([])
+        detuning_rotations = np.array([])
 
     return DynamicDecouplingSequence(
         duration=duration,
@@ -682,11 +682,11 @@ def new_walsh_sequence(duration, paley_order, pre_post_rotation=False, name=None
             ** binary_order[hamming_weight - 1 - i]
         )
 
-    walsh_relative_offsets = []
+    _walsh_relative_offsets = []
     for i in range(samples - 1):
         if walsh_array[i] != walsh_array[i + 1]:
-            walsh_relative_offsets.append((i + 1) * (1.0 / samples))
-    walsh_relative_offsets = np.array(walsh_relative_offsets, dtype=np.float)
+            _walsh_relative_offsets.append((i + 1) * (1.0 / samples))
+    walsh_relative_offsets = np.array(_walsh_relative_offsets, dtype=float)
 
     offsets = duration * walsh_relative_offsets
     rabi_rotations = np.full(offsets.shape, np.pi)

--- a/tests/test_driven_controls.py
+++ b/tests/test_driven_controls.py
@@ -42,10 +42,10 @@ def test_driven_controls():
     """
     Tests the construction of driven controls.
     """
-    _rabi_rates = [np.pi, np.pi, 0]
-    _azimuthal_angles = [np.pi / 2, 0, -np.pi]
-    _detunings = [0, 0, 0]
-    _durations = [1, 2, 3]
+    _rabi_rates = np.array([np.pi, np.pi, 0])
+    _azimuthal_angles = np.array([np.pi / 2, 0, -np.pi])
+    _detunings = np.array([0, 0, 0])
+    _durations = np.array([1, 2, 3])
 
     _name = "driven_control"
 
@@ -68,10 +68,10 @@ def test_driven_control_default_values():
     """
     Tests driven control with default values and invalid input.
     """
-    _rabi_rates = [np.pi, np.pi, 0]
-    _azimuthal_angles = [np.pi / 2, 0, -np.pi]
-    _detunings = [0, 0, 0]
-    _durations = [1, 2, 3]
+    _rabi_rates = np.array([np.pi, np.pi, 0])
+    _azimuthal_angles = np.array([np.pi / 2, 0, -np.pi])
+    _detunings = np.array([0, 0, 0])
+    _durations = np.array([1, 2, 3])
 
     _name = "driven_control"
 
@@ -114,23 +114,23 @@ def test_driven_control_default_values():
     assert np.allclose(driven_control.detunings, np.array([0.0, 0.0, 0.0]))
     assert np.allclose(driven_control.azimuthal_angles, _azimuthal_angles)
 
-    driven_control = DrivenControl(durations=[1])
+    driven_control = DrivenControl(durations=np.array([1]))
     assert np.allclose(driven_control.rabi_rates, np.array([0.0]))
     assert np.allclose(driven_control.durations, np.array([1.0]))
     assert np.allclose(driven_control.detunings, np.array([0.0]))
     assert np.allclose(driven_control.azimuthal_angles, np.array([0.0]))
 
     with pytest.raises(ArgumentsValueError):
-        _ = DrivenControl(durations=[1], rabi_rates=[-1])
+        _ = DrivenControl(durations=np.array([1]), rabi_rates=np.array([-1]))
 
     with pytest.raises(ArgumentsValueError):
-        _ = DrivenControl(durations=[0])
+        _ = DrivenControl(durations=np.array([0]))
 
     with pytest.raises(ArgumentsValueError):
         _ = DrivenControl(
-            durations=[1],
-            rabi_rates=[1, 2],
-            azimuthal_angles=[1, 2, 3],
+            durations=np.array([1]),
+            rabi_rates=np.array([1, 2]),
+            azimuthal_angles=np.array([1, 2, 3]),
         )
 
 
@@ -138,14 +138,14 @@ def test_control_directions():
     """
     Tests if the directions method works properly.
     """
-    rabi_rates = [1, 0, 1, 0]
-    azimuthal_angles = [0, 0, np.pi / 2, 0]
-    detunings = [0, 0, 0, 1]
-    durations = [1, 1, 1, 1]
+    rabi_rates = np.array([1, 0, 1, 0])
+    azimuthal_angles = np.array([0, 0, np.pi / 2, 0])
+    detunings = np.array([0, 0, 0, 1])
+    durations = np.array([1, 1, 1, 1])
 
     name = "driven_control"
 
-    expected_directions = [[1, 0, 0], [0, 0, 0], [0, 1, 0], [0, 0, 1]]
+    expected_directions = np.array([[1, 0, 0], [0, 0, 0], [0, 1, 0], [0, 0, 1]])
 
     driven_control = DrivenControl(
         rabi_rates=rabi_rates,
@@ -162,14 +162,14 @@ def test_control_directions_with_small_amplitudes():
     """
     Tests if the directions method works with very small amplitudes.
     """
-    rabi_rates = [1e-100, 0.0, 1e-100, 0.0]
-    azimuthal_angles = [0, 0, np.pi / 2, 0]
-    detunings = [0, 0, 0, 1e-100]
-    durations = [1, 1, 1, 1]
+    rabi_rates = np.array([1e-100, 0.0, 1e-100, 0.0])
+    azimuthal_angles = np.array([0, 0, np.pi / 2, 0])
+    detunings = np.array([0, 0, 0, 1e-100])
+    durations = np.array([1, 1, 1, 1])
 
     name = "driven_control"
 
-    expected_directions = [[1, 0, 0], [0, 0, 0], [0, 1, 0], [0, 0, 1]]
+    expected_directions = np.array([[1, 0, 0], [0, 0, 0], [0, 1, 0], [0, 0, 1]])
 
     driven_control = DrivenControl(
         rabi_rates=rabi_rates,
@@ -195,10 +195,10 @@ def test_control_export():
     _name = "driven_control"
 
     driven_control = DrivenControl(
-        rabi_rates=_rabi_rates,
-        azimuthal_angles=_azimuthal_angles,
-        detunings=_detunings,
-        durations=_durations,
+        rabi_rates=np.asarray(_rabi_rates),
+        azimuthal_angles=np.asarray(_azimuthal_angles),
+        detunings=np.asarray(_detunings),
+        durations=np.asarray(_durations),
         name=_name,
     )
 
@@ -250,10 +250,10 @@ def test_plot_data():
     _durations = [1, 1.25, 1.5]
 
     driven_control = DrivenControl(
-        rabi_rates=_rabi_rates,
-        azimuthal_angles=_azimuthal_angles,
-        detunings=_detunings,
-        durations=_durations,
+        rabi_rates=np.asarray(_rabi_rates),
+        azimuthal_angles=np.asarray(_azimuthal_angles),
+        detunings=np.asarray(_detunings),
+        durations=np.asarray(_durations),
     )
 
     x_amplitude = [np.pi, 0.0, 0.0]
@@ -296,10 +296,10 @@ def test_pretty_print():
     _durations = [1.0, 1.0, 1.0]
 
     driven_control = DrivenControl(
-        rabi_rates=_rabi_rates,
-        azimuthal_angles=_azimuthal_angles,
-        detunings=_detunings,
-        durations=_durations,
+        rabi_rates=np.asarray(_rabi_rates),
+        azimuthal_angles=np.asarray(_azimuthal_angles),
+        detunings=np.asarray(_detunings),
+        durations=np.asarray(_durations),
     )
 
     _pretty_rabi_rates = ",".join(
@@ -337,10 +337,10 @@ def test_pretty_print():
     _durations = [1.0, 1.0, 1.0]
 
     driven_control = DrivenControl(
-        rabi_rates=_rabi_rates,
-        azimuthal_angles=_azimuthal_angles,
-        detunings=_detunings,
-        durations=_durations,
+        rabi_rates=np.asarray(_rabi_rates),
+        azimuthal_angles=np.asarray(_azimuthal_angles),
+        detunings=np.asarray(_detunings),
+        durations=np.asarray(_durations),
     )
 
     _pretty_rabi_rates = ",".join(["0", "0", "0"])
@@ -376,10 +376,10 @@ def test_pretty_print():
     _durations = [1.0, 1.0, 1.0]
 
     driven_control = DrivenControl(
-        rabi_rates=_rabi_rates,
-        azimuthal_angles=_azimuthal_angles,
-        detunings=_detunings,
-        durations=_durations,
+        rabi_rates=np.asarray(_rabi_rates),
+        azimuthal_angles=np.asarray(_azimuthal_angles),
+        detunings=np.asarray(_detunings),
+        durations=np.asarray(_durations),
     )
 
     _pretty_rabi_rates = ",".join(
@@ -410,10 +410,10 @@ def test_pretty_print():
 
 def test_resample_exact():
     driven_control = DrivenControl(
-        rabi_rates=[0, 2],
-        azimuthal_angles=[1.5, 0.5],
-        detunings=[1.3, 2.3],
-        durations=[1, 1],
+        rabi_rates=np.array([0, 2]),
+        azimuthal_angles=np.array([1.5, 0.5]),
+        detunings=np.array([1.3, 2.3]),
+        durations=np.array([1, 1]),
         name="control",
     )
 
@@ -429,10 +429,10 @@ def test_resample_exact():
 
 def test_resample_inexact():
     driven_control = DrivenControl(
-        rabi_rates=[0, 2],
-        azimuthal_angles=[1.5, 0.5],
-        detunings=[1.3, 2.3],
-        durations=[1, 1],
+        rabi_rates=np.array([0, 2]),
+        azimuthal_angles=np.array([1.5, 0.5]),
+        detunings=np.array([1.3, 2.3]),
+        durations=np.array([1, 1]),
         name="control",
     )
 

--- a/tests/test_dynamical_decoupling.py
+++ b/tests/test_dynamical_decoupling.py
@@ -593,10 +593,10 @@ def test_conversion_of_pulses_with_arbitrary_rabi_rotations():
     Y pulses with rabi rotations that assume arbitrary values between 0 and pi.
     """
     _duration = 3.0
-    _offsets = [0.5, 1.5, 2.5]
-    _rabi_rotations = [1.0, 2.0, 3.0]
-    _azimuthal_angles = [np.pi / 2, np.pi / 2, np.pi / 2]
-    _detuning_rotations = [0.0, 0.0, 0.0]
+    _offsets = np.array([0.5, 1.5, 2.5])
+    _rabi_rotations = np.array([1.0, 2.0, 3.0])
+    _azimuthal_angles = np.array([np.pi / 2, np.pi / 2, np.pi / 2])
+    _detuning_rotations = np.array([0.0, 0.0, 0.0])
     _name = "arbitrary_rabi_rotation_sequence"
 
     dd_sequence = DynamicDecouplingSequence(
@@ -648,10 +648,10 @@ def test_conversion_of_pulses_with_arbitrary_azimuthal_angles():
     pi-pulses with azimuthal angles that assume arbitrary values between 0 and pi/2.
     """
     _duration = 3.0
-    _offsets = [0.5, 1.5, 2.5]
-    _rabi_rotations = [np.pi, np.pi, np.pi]
-    _azimuthal_angles = [0.5, 1.0, 1.5]
-    _detuning_rotations = [0.0, 0.0, 0.0]
+    _offsets = np.array([0.5, 1.5, 2.5])
+    _rabi_rotations = np.array([np.pi, np.pi, np.pi])
+    _azimuthal_angles = np.array([0.5, 1.0, 1.5])
+    _detuning_rotations = np.array([0.0, 0.0, 0.0])
     _name = "arbitrary_azimuthal_angle_sequence"
 
     dd_sequence = DynamicDecouplingSequence(
@@ -703,10 +703,10 @@ def test_conversion_of_pulses_with_arbitrary_detuning_rotations():
     Z pulses with detuning rotations that assume arbitrary values between 0 and pi.
     """
     _duration = 3.0
-    _offsets = [0.5, 1.5, 2.5]
-    _rabi_rotations = [0.0, 0.0, 0.0]
-    _azimuthal_angles = [0.0, 0.0, 0.0]
-    _detuning_rotations = [1.0, 2.0, 3.0]
+    _offsets = np.array([0.5, 1.5, 2.5])
+    _rabi_rotations = np.array([0.0, 0.0, 0.0])
+    _azimuthal_angles = np.array([0.0, 0.0, 0.0])
+    _detuning_rotations = np.array([1.0, 2.0, 3.0])
     _name = "arbitrary_detuning_rotation_sequence"
 
     dd_sequence = DynamicDecouplingSequence(
@@ -793,10 +793,10 @@ def test_free_evolution_conversion():
 
     dd_sequence = DynamicDecouplingSequence(
         duration=_duration,
-        offsets=[],
-        rabi_rotations=[],
-        azimuthal_angles=[],
-        detuning_rotations=[],
+        offsets=np.array([]),
+        rabi_rotations=np.array([]),
+        azimuthal_angles=np.array([]),
+        detuning_rotations=np.array([]),
         name=_name,
     )
 
@@ -820,10 +820,10 @@ def test_free_evolution_conversion():
 
     _duration = 10.0
     _name = "test_sequence"
-    _offsets = [0, _duration]
-    _rabi_rotations = [np.pi / 2, np.pi / 2]
-    _azimuthal_angles = [0, 0]
-    _detuning_rotations = [0, 0]
+    _offsets = np.array([0, _duration])
+    _rabi_rotations = np.array([np.pi / 2, np.pi / 2])
+    _azimuthal_angles = np.array([0, 0])
+    _detuning_rotations = np.array([0, 0])
 
     dd_sequence = DynamicDecouplingSequence(
         duration=_duration,

--- a/tests/test_predefined_dynamical_decoupling.py
+++ b/tests/test_predefined_dynamical_decoupling.py
@@ -395,12 +395,12 @@ def test_quadratic_sequence():
     _offsets = np.zeros((outer_offset_count + 1, inner_offset_count + 1))
 
     constant = 0.5 / (outer_offset_count + 1)
-    _delta_positions = [
-        duration * (np.sin(np.pi * (k + 1) * constant)) ** 2
-        for k in range(outer_offset_count)
-    ]
-
-    _outer_offsets = np.array(_delta_positions)
+    _outer_offsets = np.array(
+        [
+            duration * (np.sin(np.pi * (k + 1) * constant)) ** 2
+            for k in range(outer_offset_count)
+        ]
+    )
     _offsets[0:outer_offset_count, -1] = _outer_offsets
 
     _outer_offsets = np.insert(
@@ -411,10 +411,9 @@ def test_quadratic_sequence():
     _inner_durations = _outer_offsets[1:] - _outer_offsets[0:-1]
 
     constant = 0.5 / (inner_offset_count + 1)
-    _delta_positions = [
-        (np.sin(np.pi * (k + 1) * constant)) ** 2 for k in range(inner_offset_count)
-    ]
-    _delta_positions = np.array(_delta_positions)
+    _delta_positions = np.array(
+        [(np.sin(np.pi * (k + 1) * constant)) ** 2 for k in range(inner_offset_count)]
+    )
     for inner_sequence_idx in range(_inner_durations.shape[0]):
         _inner_deltas = _inner_durations[inner_sequence_idx] * _delta_positions
         _inner_deltas = _outer_offsets[inner_sequence_idx] + _inner_deltas


### PR DESCRIPTION
To prepare upgrading to NumPy 1.20+, this PR fixes the type issue as type hint can work with most of the NumPy objects (instead of being `Any` before).