### PR TITLE
misc: Use positive in error messages

### DIFF
--- a/qctrlopencontrols/driven_controls/driven_control.py
+++ b/qctrlopencontrols/driven_controls/driven_control.py
@@ -107,7 +107,7 @@ class DrivenControl:
         # check if all the durations are greater than zero
         check_arguments(
             all(durations > 0),
-            "Duration of driven control segments must all be greater than zero.",
+            "Duration of driven control segments must all be positive.",
             {"durations": durations},
         )
 
@@ -144,10 +144,10 @@ class DrivenControl:
         azimuthal_angles = np.asarray(azimuthal_angles, dtype=float)
         detunings = np.asarray(detunings, dtype=float)
 
-        # check if all the rabi_rates are greater than zero
+        # check if all the rabi_rates are non-negative
         check_arguments(
             all(rabi_rates >= 0.0),
-            "All Rabi rates must be greater than zero.",
+            "All Rabi rates must be non-negative.",
             {"rabi_rates": rabi_rates},
         )
 

--- a/qctrlopencontrols/driven_controls/driven_control.py
+++ b/qctrlopencontrols/driven_controls/driven_control.py
@@ -45,7 +45,7 @@ class DrivenControl:
         of segments.
     rabi_rates : np.ndarray, optional
         The Rabi rates :math:`\{\Omega_n\}` for each segment, in units of radians per second. Every
-        element must be non-negative. Represented as a 1D array of length :math:`N`, where :math:`N`
+        element must be nonnegative. Represented as a 1D array of length :math:`N`, where :math:`N`
         is number of segments. You can omit this field if the Rabi rate is zero on all segments.
     azimuthal_angles : np.ndarray, optional
         The azimuthal angles :math:`\{\phi_n\}` for each segment. Represented as a 1D array of
@@ -144,10 +144,10 @@ class DrivenControl:
         azimuthal_angles = np.asarray(azimuthal_angles, dtype=float)
         detunings = np.asarray(detunings, dtype=float)
 
-        # check if all the rabi_rates are non-negative
+        # check if all the rabi_rates are nonnegative
         check_arguments(
             all(rabi_rates >= 0.0),
-            "All Rabi rates must be non-negative.",
+            "All Rabi rates must be nonnegative.",
             {"rabi_rates": rabi_rates},
         )
 

--- a/qctrlopencontrols/driven_controls/predefined.py
+++ b/qctrlopencontrols/driven_controls/predefined.py
@@ -42,7 +42,7 @@ def _validate_rabi_parameters(rabi_rotation: float, maximum_rabi_rate: float) ->
 
     check_arguments(
         maximum_rabi_rate > 0,
-        "Maximum Rabi angular frequency should be greater than zero.",
+        "Maximum Rabi angular frequency must be positive.",
         {"maximum_rabi_rate": maximum_rabi_rate},
     )
 
@@ -1040,19 +1040,19 @@ def new_gaussian_control(
 
     check_arguments(
         duration > 0.0,
-        "Pulse duration must be greater than zero.",
+        "Pulse duration must be positive.",
         {"duration": duration},
     )
 
     check_arguments(
         segment_count > 0,
-        "Segment count must be greater than zero.",
+        "Segment count must be positive.",
         {"segment_count": segment_count},
     )
 
     check_arguments(
         width > 0.0,
-        "Width of ideal Gaussian pulse must be greater than zero.",
+        "Width of ideal Gaussian pulse must be positive.",
         {"width": width},
     )
 
@@ -1124,13 +1124,13 @@ def new_modulated_gaussian_control(
 
     check_arguments(
         maximum_rabi_rate > 0.0,
-        "Maximum Rabi rate must be greater than zero.",
+        "Maximum Rabi rate must be positive.",
         {"maximum_rabi_rate": maximum_rabi_rate},
     )
 
     check_arguments(
         minimum_segment_duration > 0.0,
-        "Minimum segment duration must be greater than zero.",
+        "Minimum segment duration must be positive.",
         {"minimum_segment_duration": minimum_segment_duration},
     )
 
@@ -1289,19 +1289,19 @@ def new_drag_control(
 
     check_arguments(
         duration > 0.0,
-        "Pulse duration must be greater than zero.",
+        "Pulse duration must be positive.",
         {"duration": duration},
     )
 
     check_arguments(
         segment_count > 0,
-        "Segment count must be greater than zero.",
+        "Segment count must be positive.",
         {"segment_count": segment_count},
     )
 
     check_arguments(
         width > 0.0,
-        "Width of ideal Gaussian pulse must be greater than zero.",
+        "Width of ideal Gaussian pulse must be positive.",
         {"width": width},
     )
 

--- a/qctrlopencontrols/dynamic_decoupling_sequences/dynamic_decoupling_sequence.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/dynamic_decoupling_sequence.py
@@ -98,7 +98,7 @@ class DynamicDecouplingSequence:
         rabi_rotations = np.asarray(rabi_rotations, dtype=float)
         check_arguments(
             np.all(rabi_rotations >= 0),
-            "Rabi rotations must be non-negative.",
+            "Rabi rotations must be nonnegative.",
             {"rabi_rotations": rabi_rotations},
         )
 

--- a/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
@@ -173,7 +173,7 @@ def new_ramsey_sequence(duration, pre_post_rotation=False, name=None):
     """
     check_arguments(
         duration > 0,
-        "Sequence duration must be greater than zero.",
+        "Sequence duration must be positive.",
         {"duration": duration},
     )
 
@@ -230,7 +230,7 @@ def new_spin_echo_sequence(duration, pre_post_rotation=False, name=None):
 
     check_arguments(
         duration > 0,
-        "Sequence duration must be greater than zero.",
+        "Sequence duration must be positive.",
         {"duration": duration},
     )
 
@@ -305,12 +305,12 @@ def new_carr_purcell_sequence(
 
     check_arguments(
         duration > 0,
-        "Sequence duration must be greater than zero.",
+        "Sequence duration must be positive.",
         {"duration": duration},
     )
     check_arguments(
         offset_count >= 1,
-        "Number of offsets must be greater than zero.",
+        "Number of offsets must be non-negativei.",
         {"offset_count": offset_count},
     )
 
@@ -388,12 +388,12 @@ def new_cpmg_sequence(duration, offset_count, pre_post_rotation=False, name=None
 
     check_arguments(
         duration > 0,
-        "Sequence duration must be greater than zero.",
+        "Sequence duration must be positive.",
         {"duration": duration},
     )
     check_arguments(
         offset_count >= 1,
-        "Number of offsets must be greater than zero.",
+        "Number of offsets must be non-negative.",
         {"offset_count": offset_count},
     )
 
@@ -467,12 +467,12 @@ def new_uhrig_sequence(duration, offset_count, pre_post_rotation=False, name=Non
 
     check_arguments(
         duration > 0,
-        "Sequence duration must be greater than zero.",
+        "Sequence duration must be positive.",
         {"duration": duration},
     )
     check_arguments(
         offset_count >= 1,
-        "Number of offsets must be greater than zero.",
+        "Number of offsets must be non-negative.",
         {"offset_count": offset_count},
     )
 
@@ -546,12 +546,12 @@ def new_periodic_sequence(duration, offset_count, pre_post_rotation=False, name=
 
     check_arguments(
         duration > 0,
-        "Sequence duration must be greater than zero.",
+        "Sequence duration must be positve.",
         {"duration": duration},
     )
     check_arguments(
         offset_count >= 1,
-        "Number of offsets must be greater than zero.",
+        "Number of offsets must be non-negative.",
         {"offset_count": offset_count},
     )
 
@@ -649,7 +649,7 @@ def new_walsh_sequence(duration, paley_order, pre_post_rotation=False, name=None
 
     check_arguments(
         duration > 0,
-        "Sequence duration must be greater than zero.",
+        "Sequence duration must be positive.",
         {"duration": duration},
     )
     check_arguments(
@@ -771,17 +771,17 @@ def new_quadratic_sequence(
 
     check_arguments(
         duration > 0,
-        "Sequence duration must be greater than zero.",
+        "Sequence duration must be positive.",
         {"duration": duration},
     )
     check_arguments(
         inner_offset_count >= 1,
-        "Number of offsets of inner pulses must be greater than zero.",
+        "Number of offsets of inner pulses must be non-negative.",
         {"inner_offset_count": inner_offset_count},
     )
     check_arguments(
         outer_offset_count >= 1,
-        "Number of offsets of outer pulses must be greater than zero.",
+        "Number of offsets of outer pulses must be non-negative.",
         {"outer_offset_count": outer_offset_count},
     )
 
@@ -893,12 +893,12 @@ def new_x_concatenated_sequence(
 
     check_arguments(
         duration > 0,
-        "Sequence duration must be greater than zero.",
+        "Sequence duration must be positive.",
         {"duration": duration},
     )
     check_arguments(
         concatenation_order >= 1,
-        "Concatenation oder must be greater than zero.",
+        "Concatenation oder must be non-negative.",
         {"concatenation_order": concatenation_order},
     )
 
@@ -998,12 +998,12 @@ def new_xy_concatenated_sequence(
 
     check_arguments(
         duration > 0,
-        "Sequence duration must be greater than zero.",
+        "Sequence duration must be positive.",
         {"duration": duration},
     )
     check_arguments(
         concatenation_order >= 1,
-        "Concatenation oder must be greater than zero.",
+        "Concatenation oder must be non-negative.",
         {"concatenation_order": concatenation_order},
     )
 

--- a/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
@@ -898,7 +898,7 @@ def new_x_concatenated_sequence(
     )
     check_arguments(
         concatenation_order >= 1,
-        "Concatenation oder must be positive.",
+        "Concatenation order must be positive.",
         {"concatenation_order": concatenation_order},
     )
 

--- a/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
@@ -1003,7 +1003,7 @@ def new_xy_concatenated_sequence(
     )
     check_arguments(
         concatenation_order >= 1,
-        "Concatenation oder must be positive.",
+        "Concatenation order must be positive.",
         {"concatenation_order": concatenation_order},
     )
 

--- a/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
@@ -310,7 +310,7 @@ def new_carr_purcell_sequence(
     )
     check_arguments(
         offset_count >= 1,
-        "Number of offsets must be non-negativei.",
+        "Number of offsets must be positive.",
         {"offset_count": offset_count},
     )
 
@@ -393,7 +393,7 @@ def new_cpmg_sequence(duration, offset_count, pre_post_rotation=False, name=None
     )
     check_arguments(
         offset_count >= 1,
-        "Number of offsets must be non-negative.",
+        "Number of offsets must be positive.",
         {"offset_count": offset_count},
     )
 
@@ -472,7 +472,7 @@ def new_uhrig_sequence(duration, offset_count, pre_post_rotation=False, name=Non
     )
     check_arguments(
         offset_count >= 1,
-        "Number of offsets must be non-negative.",
+        "Number of offsets must be positive.",
         {"offset_count": offset_count},
     )
 
@@ -551,7 +551,7 @@ def new_periodic_sequence(duration, offset_count, pre_post_rotation=False, name=
     )
     check_arguments(
         offset_count >= 1,
-        "Number of offsets must be non-negative.",
+        "Number of offsets must be positive.",
         {"offset_count": offset_count},
     )
 
@@ -776,12 +776,12 @@ def new_quadratic_sequence(
     )
     check_arguments(
         inner_offset_count >= 1,
-        "Number of offsets of inner pulses must be non-negative.",
+        "Number of offsets of inner pulses must be positive.",
         {"inner_offset_count": inner_offset_count},
     )
     check_arguments(
         outer_offset_count >= 1,
-        "Number of offsets of outer pulses must be non-negative.",
+        "Number of offsets of outer pulses must be positive.",
         {"outer_offset_count": outer_offset_count},
     )
 
@@ -898,7 +898,7 @@ def new_x_concatenated_sequence(
     )
     check_arguments(
         concatenation_order >= 1,
-        "Concatenation oder must be non-negative.",
+        "Concatenation oder must be positive.",
         {"concatenation_order": concatenation_order},
     )
 
@@ -1003,7 +1003,7 @@ def new_xy_concatenated_sequence(
     )
     check_arguments(
         concatenation_order >= 1,
-        "Concatenation oder must be non-negative.",
+        "Concatenation oder must be positive.",
         {"concatenation_order": concatenation_order},
     )
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Uses positive instead of greater than zero in error messages if value > 0
- Uses non-negative in error messages instead of greater than zero in error messages if value >= 0