### PR TITLE
ci: Remove duplicate vault login

### DIFF
--- a/.github/workflows/on-release.yaml
+++ b/.github/workflows/on-release.yaml
@@ -47,7 +47,6 @@ jobs:
             --suffix -docs
       - name: Update Sphinx deployment in Kubernetes (Production)
         run: |
-          ./ci vault login -r ${{ secrets.VAULT_ROLE_ID }} -s ${{ secrets.VAULT_SECRET_ID }}
           ./ci vault awsKey -t $(cat .token) -r deploy-eks-prod -o ./.aws-credentials
           ./ci docker run qctrl/ci-images:google-cloud-sdk-ci sh -- -c '
             . ./.aws-credentials;


### PR DESCRIPTION
We only need one vault login in the workflow to publish the documentation.

This pull request removes the duplicate vault login for the python-open-controls CI.

Changes proposed in this pull request:
- Remove duplicate vault login in the CI workflow that publishes reference documentation.