### PR TITLE
docs: Use package name in the documentation

### DIFF
--- a/docs/_templates/qctrlopencontrols/qctrlopencontrols.rst
+++ b/docs/_templates/qctrlopencontrols/qctrlopencontrols.rst
@@ -2,7 +2,7 @@
 
 .. _{{fullname}}:
 
-Q-CTRL Open Controls
+Open Controls
 {{ underline }}{{ underline }}
 
 .. autosummary::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
-Q-CTRL Open Controls Python package
-===================================
+Open Controls
+=============
 
 The Q-CTRL Open Controls Python package provides a comprehensive library of published and tested error-robust quantum control protocols.
 


### PR DESCRIPTION
Use the [package name](https://code.q-ctrl.com/naming-conventions#packages) in the reference documentation, as specified in the [documentation guidelines](https://code.q-ctrl.com/documentation#user-documentation).

Changes proposed in this pull request:
- Use the package name (Open Controls) in the title of the user reference documentation.