### PR TITLE
ci: Remove broken poetry URL in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ packages = [
     { include = "qctrlopencontrols" },
 ]
 
-[tool.poetry.dependencies]  # https://poetry.eustace.io/docs/versions
+[tool.poetry.dependencies]
 python = ">=3.7.2,<3.12"
 numpy = [
     {version = "^1.21.6", python = ">=3.7,<3.8"},


### PR DESCRIPTION
The URL `https://poetry.eustace.io/docs/versions` sends you to a 404 error, so it might be best to remove it from pyproject.toml.

This comment is present in many repos, so I've attempted to use Microplane to make it easier to deploy the changes everywhere.

Changes proposed in this pull request:
- Remove broken link to `https://poetry.eustace.io/docs/versions` from `pyproject.toml`.