### PR TITLE
docs: Fix small issues in docstrings

### DIFF
--- a/qctrlopencontrols/driven_controls/driven_control.py
+++ b/qctrlopencontrols/driven_controls/driven_control.py
@@ -383,7 +383,7 @@ class DrivenControl:
         Parameters
         ----------
         coordinates : str, optional
-            Indicates the co-ordinate system requested. Must be
+            Indicates the coordinate system requested. Must be
             'cylindrical'or 'cartesian'. Defaults to 'cylindrical'.
 
         Returns
@@ -428,10 +428,10 @@ class DrivenControl:
         filename : str
             Name and path of the file to save the control into.
         file_type : str, optional
-            One of 'CSV' or 'JSON'; defaults to 'CSV'.
+            One of 'CSV' or 'JSON'. Defaults to 'CSV'.
         coordinates : str, optional
-            Indicates the co-ordinate system requested. Must be one of
-            'cylindrical', 'cartesian'; defaults to 'cylindrical'
+            Indicates the coordinate system requested. Must be one of
+            'cylindrical' or 'cartesian'. Defaults to 'cylindrical'.
         """
 
         control_info = self._qctrl_expanded_export_content(coordinates=coordinates)

--- a/qctrlopencontrols/driven_controls/predefined.py
+++ b/qctrlopencontrols/driven_controls/predefined.py
@@ -36,7 +36,7 @@ def _validate_rabi_parameters(rabi_rotation: float, maximum_rabi_rate: float) ->
         The total polar angle to be performed by the pulse.
         Defined in polar coordinates.
     maximum_rabi_rate : float
-        The maximum rabi frequency for the pulse.
+        The maximum Rabi frequency for the pulse.
     """
 
     check_arguments(

--- a/qctrlopencontrols/dynamic_decoupling_sequences/dynamic_decoupling_sequence.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/dynamic_decoupling_sequence.py
@@ -47,7 +47,7 @@ class DynamicDecouplingSequence:
     offsets : np.ndarray
         The times offsets :math:`\{t_j\}` in seconds for the center of pulses.
     rabi_rotations : np.ndarray
-        The rabi rotation :math:`\omega_j` at each time offset :math:`t_j`.
+        The Rabi rotation :math:`\omega_j` at each time offset :math:`t_j`.
     azimuthal_angles : np.ndarray
         The azimuthal angle :math:`\phi_j` at each time offset :math:`t_j`.
     detuning_rotations : np.ndarray
@@ -235,18 +235,18 @@ class DynamicDecouplingSequence:
             Name and path of the file to save the control into.
         file_format : str
             Specified file format for saving the control. Defaults to
-            'Q-CTRL expanded'; Currently it does not support any other format.
+            'Q-CTRL expanded'. Currently it does not support any other format.
             For detail of the `Q-CTRL Expanded Format` consult
             :py:meth:`DrivenControl.export_to_file`.
         file_type : str, optional
             One of 'CSV' or 'JSON'. Defaults to 'CSV'.
         coordinates : str, optional
-            Indicates the co-ordinate system requested. Must be one of
-            'cylindrical', 'cartesian'; defaults to 'cylindrical'
+            Indicates the coordinate system requested. Must be one of
+            'cylindrical' or 'cartesian'. Defaults to 'cylindrical'.
         maximum_rabi_rate : float, optional
-            Maximum Rabi Rate; Defaults to :math:`2\pi`.
+            Maximum Rabi rate. Defaults to :math:`2\pi`.
         maximum_detuning_rate : float, optional
-            Maximum Detuning Rate; Defaults to :math:`2\pi`.
+            Maximum detuning rate. Defaults to :math:`2\pi`.
 
         Raises
         ------
@@ -255,9 +255,8 @@ class DynamicDecouplingSequence:
 
         Notes
         -----
-        The sequence is converted to a driven control using the maximum rabi and detuning
-        rate. The driven control is then exported. This is done to facilitate a coherent
-        integration with Q-CTRL BLACK OPAL's 1-Qubit workspace.
+        The sequence is converted to a driven control using the maximum Rabi and detuning
+        rate. The driven control is then exported.
         """
 
         convert_dds_to_driven_control(

--- a/tests/test_dynamical_decoupling.py
+++ b/tests/test_dynamical_decoupling.py
@@ -567,7 +567,7 @@ def test_conversion_of_z_pi_2_pulses_at_extremities():
 def test_conversion_of_pulses_with_arbitrary_rabi_rotations():
     """
     Tests if the method to convert a DDS to driven controls handles properly
-    Y pulses with rabi rotations that assume arbitrary values between 0 and pi.
+    Y pulses with Rabi rotations that assume arbitrary values between 0 and pi.
     """
     _duration = 3.0
     _offsets = np.array([0.5, 1.5, 2.5])


### PR DESCRIPTION
Changes proposed in this pull request:

- Fix capitalization of Rabi and spelling of coordinate.
- Remove mention of BLACK OPAL.
- Improve consistency of export method docstrings.
