### PR TITLE
build: Do not show type hint in the signature

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -112,6 +112,9 @@ html_theme_options = {
 # Option to automatically generate summaries.
 autosummary_generate = True
 
+# Hide type hints in signatures.
+autodoc_typehints = "none"
+
 public_apis = qctrlopencontrols.__all__
 
 # the key of autosummary_context can be used

--- a/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
@@ -389,7 +389,7 @@ def new_cpmg_sequence(
     References
     ----------
     .. [#] `S. Meiboom and D. Gill, Review of Scientific Instruments 29:8, 688 (1958).
-        <https://link.aps.org/doi/10.1063/1.1716296>`_
+        <https://doi.org/10.1063/1.1716296>`_
     """
 
     check_arguments(


### PR DESCRIPTION
See context in https://github.com/qctrl/python-visualizer/pull/266

Also fix a link in the doc.

