### PR TITLE
docs: Use prod search index in documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -103,9 +103,10 @@ html_theme_options = {
     "collapse_navigation": False,
     "includehidden": False,
     # Q-CTRL Sphinx Theme options.
-    "docsearch_api_key": "08c69ce3179bc7b1674919d9aba36fae",
+    # Overrides default search credentials to use the prod search index.
+    "docsearch_api_key": "ed4ee1863f66bb3eba9583582f8d63fb",
     "docsearch_app_id": "21BIPDHNCR",
-    "docsearch_index_name": "dev.docs.q-ctrl.com",
+    "docsearch_index_name": "docs.q-ctrl.com",
     "segment_write_key": "1U3lCPScREFDrSg6648L978jF9lB0LAM",
 }
 


### PR DESCRIPTION
(This pull request assumes that using the same search service as the rest of the docs is a requirement for the reference docs. If it is not, we can find other solutions in the longer term.)

There are two search indices for the Q-CTRL docs, one for prod and one for dev. The Q-CTRL Sphinx Theme uses the dev index by default, but as there's no mechanism to update those credentials automatically, we end up with the dev search index being used by [the reference documentation in prod as well](https://docs.q-ctrl.com/open-controls/references/qctrl-open-controls/). This means that any search in prod will lead to results in dev, which can be confusing to the users.

Lacking a way to automatically update which index to use, in might be better to use the prod index from the start.

Changes proposed in this pull request:
- Override Q-CTRL Sphinx Theme search index defaults to use the prod search index instead.