### PR TITLE
docs: Update segment write key to use the prod environment

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -102,6 +102,8 @@ html_theme_options = {
     # Toc options
     "collapse_navigation": False,
     "includehidden": False,
+    # Update to prod key, so Intercom will use the prod environment.
+    "segment_write_key": "XOb2NWg1wZZsUZtkwJWvP60VEVdAHA4k",
 }
 
 # Option to automatically generate summaries.


### PR DESCRIPTION
Changes proposed in this pull request:
- Update the segment key used in the reference docs to the prod one, so that Intercom will stop using the "Q-CTRL Test" environment.