### PR TITLE
docs: Fetch segment write key from the Vault

### DIFF
--- a/.github/workflows/on-release.yaml
+++ b/.github/workflows/on-release.yaml
@@ -33,10 +33,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Build Sphinx Image and Push to DockerHub
+      - name: Retrieve segment write key (Production)
         run: |
           source <(curl -sL http://ci.q-ctrl.com)
           ./ci vault login -r ${{ secrets.VAULT_ROLE_ID }} -s ${{ secrets.VAULT_SECRET_ID }}
+          ./ci vault get -k SEGMENT_WRITE_KEY -t $(cat .token) -p secret/data/python/prod -o ./docs/SEGMENT_WRITE_KEY
+      - name: Build Sphinx Image and Push to DockerHub
+        run: |
           ./ci vault get -t $(cat .token) -p secret/data/dockerhub -k hub_user -o .hub_user
           ./ci vault get -t $(cat .token) -p secret/data/dockerhub -k hub_pass -o .hub_pass
           ./ci docker buildPush \

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -8,7 +8,8 @@ RUN /scripts/install-python-dependencies.sh
 
 WORKDIR /docs
 
-RUN poetry run make html
+RUN SEGMENT_WRITE_KEY=$([ -f SEGMENT_WRITE_KEY ] && cat SEGMENT_WRITE_KEY) \
+    poetry run make html
 
 FROM nginx:1.19-alpine
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -103,9 +103,11 @@ html_theme_options = {
     # Toc options
     "collapse_navigation": False,
     "includehidden": False,
-    # Update to prod key, so Intercom will use the prod environment.
-    "segment_write_key": "XOb2NWg1wZZsUZtkwJWvP60VEVdAHA4k",
 }
+
+segment_write_key = os.getenv("SEGMENT_WRITE_KEY", "")
+if segment_write_key != "":
+    html_theme_options["segment_write_key"] = segment_write_key
 
 # Option to automatically generate summaries.
 autosummary_generate = True


### PR DESCRIPTION
Fetch the `SEGMENT_WRITE_KEY` from the Vault, instead of using a hard-coded value.

The `SEGMENT_WRITE_KEY` isn't a "real" secret (anybody can see it by looking at the source code of the reference documentation on their browsers), but if it's retrieved from a central place at least we won't have to update it in all the repos if it changes in the future. It will be sufficient to update it in the Vault.

Changes proposed in this pull request:
- Retrieve `SEGMENT_WRITE_KEY` from the Vault.