### PR TITLE
docs: Use package name as title of the reference documentation

### DIFF
--- a/docs/_templates/qctrlopencontrols/qctrlopencontrols.rst
+++ b/docs/_templates/qctrlopencontrols/qctrlopencontrols.rst
@@ -2,7 +2,7 @@
 
 .. _{{fullname}}:
 
-Open Controls
+Q-CTRL Open Controls
 {{ underline }}{{ underline }}
 
 .. autosummary::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
-Open Controls
-=============
+Q-CTRL Open Controls
+====================
 
 The Q-CTRL Open Controls Python package provides a comprehensive library of published and tested error-robust quantum control protocols.
 


### PR DESCRIPTION
According to our [coding standards](https://code.q-ctrl.com/documentation#user-documentation), the title of the documentation should match the package name.

As Open Controls is no longer listed in the Product tab of the website, the package name for this repo should be "Q-CTRL Open Controls".

Changes proposed in this pull request:
- Update title of the reference documentation to match the package name "Q-CTRL Open Controls".
