### PR TITLE
ci: Change to qctrl nginx image to allow large headers

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,4 +1,4 @@
-FROM qctrl/ci-images:python-3.10-ci AS builder
+FROM qctrl/ci-images:python-3.11-ci AS builder
 
 COPY . .
 

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -11,6 +11,6 @@ WORKDIR /docs
 RUN SEGMENT_WRITE_KEY=$([ -f SEGMENT_WRITE_KEY ] && cat SEGMENT_WRITE_KEY) \
     poetry run make html
 
-FROM nginx:1.19-alpine
+FROM qctrl/ci-images:nginx-base
 
 COPY --from=builder /docs/_build/html /usr/share/nginx/html


### PR DESCRIPTION
NOTE: Needs to have ci-image change merged in before merging so image is built/pushed

Addresses: https://qctrl.atlassian.net/browse/PR-120

Changes proposed in this pull request:
- Change to Q-CTRL nginx image to allow for large headers in requests.

For context: https://github.com/qctrl/ci-images/pull/193
